### PR TITLE
Misc cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ CFLAGS+=-g -ggdb -Wdeclaration-after-statement
 EXTRA_CFLAGS?=
 CFLAGS+=$(EXTRA_CFLAGS)
 LDFLAGS+=-pthread
-# additional debug flags:
+# debug flags:
+#   CFLAGS+=-DDEBUG
 #   CFLAGS+=-DDEBUG_TAP
 #   CFLAGS+=-DDEBUG_ETH
 #   CFLAGS+=-DDEBUG_IP

--- a/src/test/esp/esp_server.c
+++ b/src/test/esp/esp_server.c
@@ -80,8 +80,8 @@ int main(int argc, char * argv[])
         }
 
         switch (esp_mode) {
-        #if defined(WOLFSSL_AESGCM_STREAM)
         case 0:
+        #if defined(WOLFSSL_AESGCM_STREAM)
             err = wolfIP_esp_sa_new_gcm(1, in_sa_gcm, atoip4(HOST_STACK_IP),
                                         atoip4(WOLFIP_IP), ESP_ENC_GCM_RFC4106,
                                         in_enc_key, sizeof(in_enc_key));
@@ -91,8 +91,11 @@ int main(int argc, char * argv[])
                                         atoip4(HOST_STACK_IP), ESP_ENC_GCM_RFC4106,
                                         out_enc_key, sizeof(out_enc_key));
             if (err) { return err; }
-            break;
+        #else
+            printf("error: gcm stream not built in\n");
+            err = -1;
         #endif /* WOLFSSL_AESGCM_STREAM */
+            break;
         case 1:
             err = wolfIP_esp_sa_new_cbc_hmac(1, in_sa_cbc, atoip4(HOST_STACK_IP),
                                              atoip4(WOLFIP_IP),
@@ -110,8 +113,8 @@ int main(int argc, char * argv[])
                                              ESP_ICVLEN_HMAC_128);
             if (err) { return err; }
             break;
-        #ifndef NO_DES3
         case 2:
+        #ifndef NO_DES3
             err = wolfIP_esp_sa_new_des3_hmac(1, in_sa_des3, atoip4(HOST_STACK_IP),
                                               atoip4(WOLFIP_IP),
                                               in_enc_key, ESP_AUTH_SHA256_RFC4868,
@@ -125,8 +128,11 @@ int main(int argc, char * argv[])
                                               out_auth_key, sizeof(out_auth_key),
                                               ESP_ICVLEN_HMAC_128);
             if (err) { return err; }
-            break;
+        #else
+            printf("error: des3 not built in\n");
+            err = -1;
         #endif /* !NO_DES3 */
+            break;
         case 3:
             err = wolfIP_esp_sa_new_gcm(1, in_sa_gmac, atoip4(HOST_STACK_IP),
                                         atoip4(WOLFIP_IP), ESP_ENC_GCM_RFC4543,
@@ -143,6 +149,7 @@ int main(int argc, char * argv[])
             break;
         }
     }
+    if (err) { return err; }
 
     // Create a socket
     if ((server_fd = socket(AF_INET, type, 0)) < 0) {

--- a/src/test/esp/test_esp.c
+++ b/src/test/esp/test_esp.c
@@ -532,6 +532,80 @@ int main(int argc, char **argv)
         }
     }
 
+    if (!disable_ipsec) {
+        switch (mode) {
+        case 0:
+        #if defined(WOLFSSL_AESGCM_STREAM)
+            err = wolfIP_esp_sa_new_gcm(1, in_sa_gcm, atoip4(HOST_STACK_IP),
+                                        atoip4(WOLFIP_IP), ESP_ENC_GCM_RFC4106,
+                                        in_enc_key, sizeof(in_enc_key));
+            if (err) { return err; }
+
+            err = wolfIP_esp_sa_new_gcm(0, out_sa_gcm, atoip4(WOLFIP_IP),
+                                        atoip4(HOST_STACK_IP), ESP_ENC_GCM_RFC4106,
+                                        out_enc_key, sizeof(out_enc_key));
+            if (err) { return err; }
+        #else
+            printf("error: gcm stream not built in\n");
+            err = -1;
+        #endif /* WOLFSSL_AESGCM_STREAM */
+            break;
+        case 1:
+            err = wolfIP_esp_sa_new_cbc_hmac(1, in_sa_cbc, atoip4(HOST_STACK_IP),
+                                             atoip4(WOLFIP_IP),
+                                             in_enc_key, sizeof(in_enc_key) - 4,
+                                             ESP_AUTH_SHA256_RFC4868,
+                                             in_auth_key, sizeof(in_auth_key),
+                                             ESP_ICVLEN_HMAC_128);
+            if (err) { return err; }
+
+            err = wolfIP_esp_sa_new_cbc_hmac(0, out_sa_cbc, atoip4(WOLFIP_IP),
+                                             atoip4(HOST_STACK_IP),
+                                             out_enc_key, sizeof(out_enc_key) - 4,
+                                             ESP_AUTH_SHA256_RFC4868,
+                                             out_auth_key, sizeof(out_auth_key),
+                                             ESP_ICVLEN_HMAC_128);
+            if (err) { return err; }
+            break;
+        case 2:
+        #ifndef NO_DES3
+            err = wolfIP_esp_sa_new_des3_hmac(1, in_sa_des3, atoip4(HOST_STACK_IP),
+                                              atoip4(WOLFIP_IP),
+                                              in_enc_key, ESP_AUTH_SHA256_RFC4868,
+                                              in_auth_key, sizeof(in_auth_key),
+                                              ESP_ICVLEN_HMAC_128);
+            if (err) { return err; }
+
+            err = wolfIP_esp_sa_new_des3_hmac(0, out_sa_des3, atoip4(WOLFIP_IP),
+                                              atoip4(HOST_STACK_IP),
+                                              out_enc_key, ESP_AUTH_SHA256_RFC4868,
+                                              out_auth_key, sizeof(out_auth_key),
+                                              ESP_ICVLEN_HMAC_128);
+            if (err) { return err; }
+        #else
+            printf("error: des3 not built in\n");
+            err = -1;
+        #endif /* !NO_DES3 */
+            break;
+        case 3:
+            err = wolfIP_esp_sa_new_gcm(1, in_sa_gmac, atoip4(HOST_STACK_IP),
+                                        atoip4(WOLFIP_IP), ESP_ENC_GCM_RFC4543,
+                                        in_enc_key, sizeof(in_enc_key));
+            if (err) { return err; }
+
+            err = wolfIP_esp_sa_new_gcm(0, out_sa_gmac, atoip4(WOLFIP_IP),
+                                        atoip4(HOST_STACK_IP), ESP_ENC_GCM_RFC4543,
+                                        out_enc_key, sizeof(out_enc_key));
+            if (err) { return err; }
+            break;
+
+        default:
+            break;
+        }
+    }
+    if (err) { return err; }
+
+    /* init wolfip now. */
     wolfIP_init_static(&s);
     tapdev = wolfIP_getdev(s);
     if (!tapdev) {
@@ -559,72 +633,6 @@ int main(int argc, char **argv)
             atoip4(HOST_STACK_IP));
     printf("IP: manually configured\n");
     inet_pton(AF_INET, WOLFIP_IP, &srv_ip);
-
-    if (!disable_ipsec) {
-        switch (mode) {
-        #if defined(WOLFSSL_AESGCM_STREAM)
-        case 0:
-            err = wolfIP_esp_sa_new_gcm(1, in_sa_gcm, atoip4(HOST_STACK_IP),
-                                        atoip4(WOLFIP_IP), ESP_ENC_GCM_RFC4106,
-                                        in_enc_key, sizeof(in_enc_key));
-            if (err) { return err; }
-
-            err = wolfIP_esp_sa_new_gcm(0, out_sa_gcm, atoip4(WOLFIP_IP),
-                                        atoip4(HOST_STACK_IP), ESP_ENC_GCM_RFC4106,
-                                        out_enc_key, sizeof(out_enc_key));
-            if (err) { return err; }
-            break;
-        #endif /* WOLFSSL_AESGCM_STREAM */
-        case 1:
-            err = wolfIP_esp_sa_new_cbc_hmac(1, in_sa_cbc, atoip4(HOST_STACK_IP),
-                                             atoip4(WOLFIP_IP),
-                                             in_enc_key, sizeof(in_enc_key) - 4,
-                                             ESP_AUTH_SHA256_RFC4868,
-                                             in_auth_key, sizeof(in_auth_key),
-                                             ESP_ICVLEN_HMAC_128);
-            if (err) { return err; }
-
-            err = wolfIP_esp_sa_new_cbc_hmac(0, out_sa_cbc, atoip4(WOLFIP_IP),
-                                             atoip4(HOST_STACK_IP),
-                                             out_enc_key, sizeof(out_enc_key) - 4,
-                                             ESP_AUTH_SHA256_RFC4868,
-                                             out_auth_key, sizeof(out_auth_key),
-                                             ESP_ICVLEN_HMAC_128);
-            if (err) { return err; }
-            break;
-        #ifndef NO_DES3
-        case 2:
-            err = wolfIP_esp_sa_new_des3_hmac(1, in_sa_des3, atoip4(HOST_STACK_IP),
-                                              atoip4(WOLFIP_IP),
-                                              in_enc_key, ESP_AUTH_SHA256_RFC4868,
-                                              in_auth_key, sizeof(in_auth_key),
-                                              ESP_ICVLEN_HMAC_128);
-            if (err) { return err; }
-
-            err = wolfIP_esp_sa_new_des3_hmac(0, out_sa_des3, atoip4(WOLFIP_IP),
-                                              atoip4(HOST_STACK_IP),
-                                              out_enc_key, ESP_AUTH_SHA256_RFC4868,
-                                              out_auth_key, sizeof(out_auth_key),
-                                              ESP_ICVLEN_HMAC_128);
-            if (err) { return err; }
-            break;
-        #endif /* !NO_DES3 */
-        case 3:
-            err = wolfIP_esp_sa_new_gcm(1, in_sa_gmac, atoip4(HOST_STACK_IP),
-                                        atoip4(WOLFIP_IP), ESP_ENC_GCM_RFC4543,
-                                        in_enc_key, sizeof(in_enc_key));
-            if (err) { return err; }
-
-            err = wolfIP_esp_sa_new_gcm(0, out_sa_gmac, atoip4(WOLFIP_IP),
-                                        atoip4(HOST_STACK_IP), ESP_ENC_GCM_RFC4543,
-                                        out_enc_key, sizeof(out_enc_key));
-            if (err) { return err; }
-            break;
-
-        default:
-            break;
-        }
-    }
 
     /* Server side test */
     test_wolfip_echoserver(s, srv_ip);

--- a/src/test/unit/unit_esp.c
+++ b/src/test/unit/unit_esp.c
@@ -937,13 +937,7 @@ static void do_roundtrip_cbc_hmac(uint8_t *enc_key, uint8_t enc_key_len,
     /* --- Wrap --- */
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
-    /* esp_send normally fixes these up; we must do it manually. */
     frame_len   = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto   = 0x32U; /* IP proto = ESP */
-    ip->len     = ee16(ip_len);
-    ip->csum    = 0U;
-    iphdr_set_checksum(ip);
 
     /* --- Unwrap --- */
     ret = esp_transport_unwrap(ip, &frame_len);
@@ -1047,12 +1041,7 @@ START_TEST(test_roundtrip_des3_sha256)
 
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
     frame_len = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto = 0x32U;
-    ip->len   = ee16(ip_len);
-    ip->csum  = 0U;
-    iphdr_set_checksum(ip);
 
     ret = esp_transport_unwrap(ip, &frame_len);
     ck_assert_int_eq(ret, 0);
@@ -1099,12 +1088,7 @@ START_TEST(test_roundtrip_aes_gcm_rfc4106)
 
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
     frame_len = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto = 0x32U;
-    ip->len   = ee16(ip_len);
-    ip->csum  = 0U;
-    iphdr_set_checksum(ip);
 
     ret = esp_transport_unwrap(ip, &frame_len);
     ck_assert_int_eq(ret, 0);
@@ -1149,12 +1133,7 @@ START_TEST(test_roundtrip_aes_gmac_rfc4543)
 
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
     frame_len = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto = 0x32U;
-    ip->len   = ee16(ip_len);
-    ip->csum  = 0U;
-    iphdr_set_checksum(ip);
 
     ret = esp_transport_unwrap(ip, &frame_len);
     ck_assert_int_eq(ret, 0);
@@ -1204,12 +1183,7 @@ static void do_icv_tamper(void)
 
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
     frame_len = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto = 0x32U;
-    ip->len   = ee16(ip_len);
-    ip->csum  = 0U;
-    iphdr_set_checksum(ip);
 
     /* esp_len = ip_len - IP_HEADER_LEN.  The ICV occupies the last
      * ESP_ICVLEN_HMAC_128 (16) bytes of ip->data[0..esp_len-1]. */
@@ -1264,12 +1238,7 @@ START_TEST(test_ciphertext_tamper_cbc_sha256)
 
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
     frame_len = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto = 0x32U;
-    ip->len   = ee16(ip_len);
-    ip->csum  = 0U;
-    iphdr_set_checksum(ip);
 
     ip->data[ct_offset] ^= 0x01U; /* single bit flip in ciphertext */
 
@@ -1364,12 +1333,7 @@ START_TEST(test_ip_recv_esp_transport_delivers_udp_payload)
 
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
     frame_len = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto = 0x32U;
-    ip->len = ee16(ip_len);
-    ip->csum = 0U;
-    iphdr_set_checksum(ip);
 
     ip_recv(&s, 0, ip, frame_len);
 
@@ -1413,12 +1377,7 @@ START_TEST(test_ip_recv_esp_transport_unwrap_failure_drops_packet)
 
     ret = esp_transport_wrap(ip, &ip_len);
     ck_assert_int_eq(ret, 0);
-
     frame_len = (uint32_t)ip_len + ETH_HEADER_LEN;
-    ip->proto = 0x32U;
-    ip->len = ee16(ip_len);
-    ip->csum = 0U;
-    iphdr_set_checksum(ip);
 
     esp_len = frame_len - ETH_HEADER_LEN - IP_HEADER_LEN;
     ip->data[esp_len - 1U] ^= 0xFFU;

--- a/src/wolfesp.c
+++ b/src/wolfesp.c
@@ -1160,6 +1160,9 @@ esp_check_icv_hmac(const wolfIP_esp_sa * esp_sa, uint8_t * esp_data,
 
     /* compare the first N bits depending on truncation type. */
     rc = esp_const_memcmp(icv, hash, esp_sa->icv_len);
+    if (rc) {
+        rc = -1;
+    }
     return rc;
 }
 
@@ -1649,7 +1652,7 @@ esp_transport_wrap(struct wolfIP_ip_packet *ip, uint16_t * ip_len)
     }
 
     if (esp_sa->icv_len) {
-        int       err = 0;
+        int err = 0;
 
         switch (esp_sa->auth) {
         case ESP_AUTH_MD5_RFC2403:
@@ -1664,7 +1667,6 @@ esp_transport_wrap(struct wolfIP_ip_packet *ip, uint16_t * ip_len)
                 if (err == 0) {
                     memcpy(icv, hash, esp_sa->icv_len);
                 }
-
             }
             break;
         #if defined(WOLFSSL_AESGCM_STREAM)

--- a/src/wolfesp.c
+++ b/src/wolfesp.c
@@ -1694,6 +1694,11 @@ esp_transport_wrap(struct wolfIP_ip_packet *ip, uint16_t * ip_len)
     wolfIP_print_esp(esp_sa, ip->data, payload_len, pad_len, ip->proto);
     #endif /* DEBUG_ESP */
 
+    /* update len, set proto to ESP 0x32 (50), recalculate iphdr checksum. */
+    ip->len = ee16(*ip_len);
+    ip->proto = 0x32;
+    ip->csum = 0;
+    iphdr_set_checksum(ip);
     return 0;
 }
 
@@ -1739,11 +1744,6 @@ esp_send(struct wolfIP_ll_dev * ll_dev, const struct wolfIP_ip_packet *ip,
         return esp_rc;
     }
 
-    /* update len, set proto to ESP 0x32 (50), recalculate iphdr checksum. */
-    esp->len = ee16(ip_final_len);
-    esp->proto = 0x32;
-    esp->csum = 0;
-    iphdr_set_checksum(esp);
     /* send it */
     ll_dev->send(ll_dev, esp, ip_final_len + ETH_HEADER_LEN);
     return 0;


### PR DESCRIPTION
## Description

- Fix error return in esp_check_icv_hmac (return -1 instead of num bytes differing).
- Refactor ip header update to esp_transport_wrap (removes duplicated code).
- Clean up esp tests so they correctly return error if built without certain alg support.