### PR TITLE
IDE/STM32Cube: fix broken pack download link (#108)

### DIFF
--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -16,7 +16,7 @@ This guide explains how to use wolfIP on any STM32 microcontroller with Ethernet
 
 ### Step 1: Install the wolfIP Pack
 
-1. Download the pack from [wolfSSL](https://www.wolfssl.com/files/ide/I-CUBE-wolfIP.pack)
+1. Download the pack from [wolfSSL](https://www.wolfssl.com/files/ide/wolfSSL.I-CUBE-wolfIP.1.0.0.pack)
 2. In STM32CubeMX: **Help → Manage Embedded Software Packages → From Local**
 3. Select `I-CUBE-wolfIP.pack` and accept the license
 


### PR DESCRIPTION
## Summary
- Fix dead link in `IDE/STM32Cube/README.md`: the published pack URL is `wolfSSL.I-CUBE-wolfIP.1.0.0.pack`, not `I-CUBE-wolfIP.pack`.

Closes #108

## Test plan
- [x] Verified `https://www.wolfssl.com/files/ide/wolfSSL.I-CUBE-wolfIP.1.0.0.pack` returns the pack (356705 bytes, valid zip).
- [x] Verified the old URL 404s.