### PR TITLE
More various fixes (F-*)

### DIFF
--- a/src/http/httpd.c
+++ b/src/http/httpd.c
@@ -300,14 +300,6 @@ static int parse_http_request(struct http_client *hc, uint8_t *buf, size_t len) 
     struct http_request req;
     struct http_url *url = NULL;
     memset(&req, 0, sizeof(struct http_request));
-    decoded_len = http_url_decode(p, len); /* Decode can be done in place */
-    if (decoded_len < 0) {
-        http_send_response_headers(hc, HTTP_STATUS_BAD_REQUEST,
-                http_status_text(HTTP_STATUS_BAD_REQUEST), "text/plain", 0);
-        return decoded_len;
-    }
-    len = (size_t)decoded_len;
-    end = p + len;
     if (len < 4)
         goto bad_request;
     /* Parse the request line */
@@ -328,6 +320,13 @@ static int parse_http_request(struct http_client *hc, uint8_t *buf, size_t len) 
         goto bad_request;
     memcpy(req.path, p, n);
     req.path[n] = '\0';
+    decoded_len = http_url_decode(req.path, n);
+    if (decoded_len < 0)
+        goto bad_request;
+    req.path[decoded_len] = '\0';
+    if (memchr(req.path, '\r', (size_t)decoded_len) ||
+            memchr(req.path, '\n', (size_t)decoded_len))
+        goto bad_request;
     p = q + 1;
     q = strchr(p, '\r');
     if (!q)

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1289,7 +1289,7 @@ Suite *wolf_suite(void)
 #ifdef IP_MULTICAST
     tcase_add_test(tc_core, test_poll_tx_udp_multicast_arp_skipped_uses_mcast_mac);
 #endif /* IP_MULTICAST */
-    /* --- unit_tests_dhcp_edges.c (43 tests) --- */
+    /* --- unit_tests_dhcp_edges.c (46 tests) --- */
     tcase_add_test(tc_core, test_dhcp_schedule_lease_timer_zero_lease_noop);
     tcase_add_test(tc_core, test_dhcp_schedule_lease_timer_null_noop);
     tcase_add_test(tc_core, test_dhcp_schedule_lease_timer_renew_gt_lease_clamped);
@@ -1307,6 +1307,9 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_msg_type_len_ne_1_not_returned);
     tcase_add_test(tc_core, test_dhcp_msg_type_pad_bytes_skipped);
     tcase_add_test(tc_core, test_dhcp_msg_type_truncated_option_returns_neg1);
+    tcase_add_test(tc_core, test_dhcp_msg_type_nak_wrong_server_id_rejected);
+    tcase_add_test(tc_core, test_dhcp_msg_type_nak_absent_server_id_rejected);
+    tcase_add_test(tc_core, test_dhcp_msg_type_nak_matching_server_id_accepted);
     tcase_add_test(tc_core, test_dhcp_parse_offer_type_ack_not_offer_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_offer_subnet_mask_len_lt4_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_offer_inner_truncated_opt2_rejected);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1215,6 +1215,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_icmp_try_deliver_tcp_error_wrong_type_ignored);
     tcase_add_test(tc_core, test_icmp_try_deliver_tcp_error_ttl_exceeded_syn_sent);
     tcase_add_test(tc_core, test_icmp_try_deliver_tcp_error_port_unreach_syn_sent_closes);
+    tcase_add_test(tc_core, test_icmp_try_deliver_tcp_error_port_unreach_bad_seq_ignored);
     tcase_add_test(tc_core, test_icmp_try_deliver_tcp_error_src_ip_mismatch_not_closed);
     tcase_add_test(tc_core, test_icmp_try_deliver_tcp_error_frag_needed_reduces_mss);
     tcase_add_test(tc_core, test_icmp_try_deliver_tcp_error_avail_too_small);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1360,7 +1360,8 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_arp_recv_reply_sender_multicast_rejected);
     tcase_add_test(tc_core, test_arp_recv_reply_sender_own_ip_rejected);
     tcase_add_test(tc_core, test_arp_recv_reply_sender_zero_ip_rejected);
-    tcase_add_test(tc_core, test_arp_recv_valid_request_caches_neighbor_when_pending);
+    tcase_add_test(tc_core, test_arp_recv_request_replies_but_reply_caches_neighbor);
+    tcase_add_test(tc_core, test_arp_recv_forged_request_cannot_poison_pending);
     tcase_add_test(tc_core, test_arp_recv_runt_packet_dropped);
     tcase_add_test(tc_core, test_ip_recv_wrong_version_dropped_v6);
     tcase_add_test(tc_core, test_ip_recv_ihl_too_small_dropped);

--- a/src/test/unit/unit_tests_dhcp_edges.c
+++ b/src/test/unit/unit_tests_dhcp_edges.c
@@ -371,8 +371,62 @@ START_TEST(test_dhcp_msg_type_truncated_option_returns_neg1)
 }
 END_TEST
 
+START_TEST(test_dhcp_msg_type_nak_wrong_server_id_rejected)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    uint8_t *p;
+
+    wolfIP_init(&s);
+    s.dhcp_xid = 0xDEADBEEFU;
+    s.dhcp_server_ip = 0x0A000001U;          /* committed server */
+
+    build_dhcp_msg_base(&s, &msg, DHCP_NAK);
+    p = (uint8_t *)msg.options + 3;          /* after MSG_TYPE TLV */
+    append_opt4(&p, DHCP_OPTION_SERVER_ID, 0x0A000002U); /* different server */
+    append_end(&p);
+
+    ck_assert_int_eq(dhcp_msg_type(&s, &msg, sizeof(msg)), -1);
+}
+END_TEST
+
+START_TEST(test_dhcp_msg_type_nak_absent_server_id_rejected)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+
+    wolfIP_init(&s);
+    s.dhcp_xid = 0xDEADBEEFU;
+    s.dhcp_server_ip = 0x0A000001U;          /* committed server */
+
+    build_dhcp_msg_base(&s, &msg, DHCP_NAK); /* no SERVER_ID option */
+    ((uint8_t *)msg.options)[3] = DHCP_OPTION_END;
+
+    ck_assert_int_eq(dhcp_msg_type(&s, &msg, sizeof(msg)), -1);
+}
+END_TEST
+
+START_TEST(test_dhcp_msg_type_nak_matching_server_id_accepted)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    uint8_t *p;
+
+    wolfIP_init(&s);
+    s.dhcp_xid = 0xDEADBEEFU;
+    s.dhcp_server_ip = 0x0A000001U;          /* committed server */
+
+    build_dhcp_msg_base(&s, &msg, DHCP_NAK);
+    p = (uint8_t *)msg.options + 3;
+    append_opt4(&p, DHCP_OPTION_SERVER_ID, 0x0A000001U); /* committed server */
+    append_end(&p);
+
+    ck_assert_int_eq(dhcp_msg_type(&s, &msg, sizeof(msg)), DHCP_NAK);
+}
+END_TEST
+
 /* -------------------------------------------------------------------------
- * dhcp_parse_offer — additional branches
+ * dhcp_parse_offer - additional branches
  * ---------------------------------------------------------------------- */
 
 START_TEST(test_dhcp_parse_offer_type_ack_not_offer_rejected)

--- a/src/test/unit/unit_tests_ip_arp_recv.c
+++ b/src/test/unit/unit_tests_ip_arp_recv.c
@@ -1175,13 +1175,17 @@ START_TEST(test_arp_recv_reply_sender_zero_ip_rejected)
 END_TEST
 
 /* =========================================================================
- * arp_recv: valid ARP request IS cached when sender IP is legitimate
+ * arp_recv: a valid ARP request is answered but does NOT install a neighbor;
+ *           only a following REPLY populates the cache
  * =========================================================================
- * Positive test: confirms the happy path around the sender validation
- * runs (sip valid → arp_store_neighbor called when pending match exists).
+ * A REQUEST must never learn a new neighbor, even when it matches an
+ * outstanding pending request -- otherwise a spoofed sender IP/MAC can
+ * poison the cache and lock out the genuine reply (CWE-290, see
+ * test_arp_recv_forged_request_cannot_poison_pending). We still reply to the
+ * request, and the genuine reply that follows resolves the pending entry.
  * We use arp_pending_record directly to bypass the arp_request rate-limit.
  */
-START_TEST(test_arp_recv_valid_request_caches_neighbor_when_pending)
+START_TEST(test_arp_recv_request_replies_but_reply_caches_neighbor)
 {
     struct wolfIP s;
     struct arp_packet arp;
@@ -1198,8 +1202,9 @@ START_TEST(test_arp_recv_valid_request_caches_neighbor_when_pending)
     ll   = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
     conf = wolfIP_ipconf_at(&s, TEST_PRIMARY_IF);
 
-    /* Pre-register a pending ARP request so learn path is triggered.
-     * arp_pending_record is the low-level helper; we use it directly. */
+    /* Pre-register a pending ARP request: even so, the request must not be
+     * allowed to learn the sender. arp_pending_record is the low-level
+     * helper; we use it directly. */
     arp_pending_record(&s, TEST_PRIMARY_IF, sender_ip);
 
     build_valid_arp_request(&arp, ll, conf->ip, sender_ip);
@@ -1208,10 +1213,91 @@ START_TEST(test_arp_recv_valid_request_caches_neighbor_when_pending)
     last_frame_sent_size = 0;
     arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
 
-    /* A reply should have been sent */
+    /* A reply should have been sent ... */
     ck_assert_uint_gt(last_frame_sent_size, 0);
-    /* Neighbor must now be in the cache */
+    /* ... but the request must NOT have installed a neighbor entry. */
+    ck_assert_int_lt(arp_neighbor_index(&s, TEST_PRIMARY_IF, sender_ip), 0);
+
+    /* The genuine reply for the still-pending request now populates it. */
+    build_valid_arp_request(&arp, ll, conf->ip, sender_ip);
+    arp.opcode = ee16(ARP_REPLY);
+    memcpy(arp.sma, sender_mac, 6);
+    memcpy(arp.tma, ll->mac, 6);
+    arp.tip = ee32(conf->ip);
+    arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
     ck_assert_int_ge(arp_neighbor_index(&s, TEST_PRIMARY_IF, sender_ip), 0);
+}
+END_TEST
+
+/*
+ * The neighbor cache for target_ip must end up holding the genuine MAC,
+ * never the attacker's.  This test FAILS against the vulnerable code.
+ */
+START_TEST(test_arp_recv_forged_request_cannot_poison_pending)
+{
+    struct wolfIP s;
+    struct arp_packet arp;
+    struct wolfIP_ll_dev *ll;
+    struct ipconf *conf;
+    const ip4 our_ip    = 0x0A000001U;
+    const ip4 target_ip = 0x0A000050U;   /* peer the victim is resolving */
+    static const uint8_t attacker_mac[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    static const uint8_t legit_mac[6]    = {0x02, 0xCA, 0xFE, 0xBA, 0xBE, 0x01};
+    uint8_t mac_out[6];
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, our_ip, 0xFFFFFF00U, 0);
+    wolfIP_filter_set_callback(NULL, NULL);
+    wolfIP_filter_set_mask(0);
+
+    ll   = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    conf = wolfIP_ipconf_at(&s, TEST_PRIMARY_IF);
+    s.last_tick = 1000;
+
+    /* (1) Victim issues an outbound ARP request for target_ip. */
+    arp_pending_record(&s, TEST_PRIMARY_IF, target_ip);
+
+    /* (2) Attacker forges a REQUEST: sender IP is the peer being resolved,
+     *     but the sender MAC is the attacker's. */
+    memset(&arp, 0, sizeof(arp));
+    memcpy(arp.eth.dst, ll->mac, 6);
+    memcpy(arp.eth.src, attacker_mac, 6);
+    arp.eth.type = ee16(ETH_TYPE_ARP);
+    arp.htype    = ee16(1);
+    arp.ptype    = ee16(0x0800);
+    arp.hlen     = 6;
+    arp.plen     = 4;
+    arp.opcode   = ee16(ARP_REQUEST);
+    memcpy(arp.sma, attacker_mac, 6);
+    arp.sip      = ee32(target_ip);
+    memset(arp.tma, 0, 6);
+    arp.tip      = ee32(conf->ip);
+    s.last_tick += 1;
+    arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
+    /* (3) The genuine reply from target_ip arrives with the real MAC. */
+    memset(&arp, 0, sizeof(arp));
+    memcpy(arp.eth.dst, ll->mac, 6);
+    memcpy(arp.eth.src, legit_mac, 6);
+    arp.eth.type = ee16(ETH_TYPE_ARP);
+    arp.htype    = ee16(1);
+    arp.ptype    = ee16(0x0800);
+    arp.hlen     = 6;
+    arp.plen     = 4;
+    arp.opcode   = ee16(ARP_REPLY);
+    memcpy(arp.sma, legit_mac, 6);
+    arp.sip      = ee32(target_ip);
+    memcpy(arp.tma, ll->mac, 6);
+    arp.tip      = ee32(conf->ip);
+    s.last_tick += 1;
+    arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
+    /* The genuine MAC must win: a forged request must never install (and
+     * then lock in) a spoofed MAC for a peer the victim is resolving. */
+    ck_assert_int_eq(arp_lookup(&s, TEST_PRIMARY_IF, target_ip, mac_out), 0);
+    ck_assert_mem_eq(mac_out, legit_mac, 6);
 }
 END_TEST
 

--- a/src/test/unit/unit_tests_proto.c
+++ b/src/test/unit/unit_tests_proto.c
@@ -2694,8 +2694,9 @@ START_TEST(test_arp_request_handling) {
     memcpy(arp_req.sma, req_mac, 6);
     arp_req.tip = ee32(device_ip);
 
-    /* Model a solicited learn: stack has an outstanding ARP request for
-     * req_ip, so the request handler is allowed to populate the cache. */
+    /* Even with an outstanding ARP request for req_ip, the request handler
+     * must not learn the sender: only a REPLY may populate the cache,
+     * otherwise a spoofed sender IP/MAC could poison it (CWE-290). */
     s.last_tick = 1000;
     arp_pending_record(&s, TEST_PRIMARY_IF, req_ip);
 
@@ -2705,9 +2706,8 @@ START_TEST(test_arp_request_handling) {
     wolfIP_poll(&s, 1001);
     wolfIP_poll(&s, 1002);
 
-    /* Check if ARP table updated with requester's MAC and IP */
-    ck_assert_int_eq(arp_lookup(&s, TEST_PRIMARY_IF, req_ip, mac), 0);
-    ck_assert_mem_eq(mac, req_mac, 6);
+    /* ARP table must NOT have been populated from the request */
+    ck_assert_int_eq(arp_lookup(&s, TEST_PRIMARY_IF, req_ip, mac), -1);
 
     /* Check if an ARP reply was generated */
     arp_reply = (struct arp_packet *)last_frame_sent;

--- a/src/test/unit/unit_tests_tcp_ack.c
+++ b/src/test/unit/unit_tests_tcp_ack.c
@@ -2321,16 +2321,16 @@ START_TEST(test_arp_recv_request_does_not_store_self_neighbor)
     for (i = 0; i < MAX_NEIGHBORS; i++) {
         if (s.arp.neighbors[i].if_idx != TEST_PRIMARY_IF)
             continue;
-        if (s.arp.neighbors[i].ip == sender_ip) {
+        if (s.arp.neighbors[i].ip == sender_ip)
             sender_count++;
-            ck_assert_mem_eq(s.arp.neighbors[i].mac, sender_mac,
-                             sizeof(sender_mac));
-        }
         if (s.arp.neighbors[i].ip == local_ip)
             self_count++;
     }
 
-    ck_assert_int_eq(sender_count, 1);
+    /* A REQUEST must never populate the cache: not our own IP (self), and
+     * -- even with an outstanding pending request -- not the sender either,
+     * since a spoofed sender IP/MAC could otherwise poison it (CWE-290). */
+    ck_assert_int_eq(sender_count, 0);
     ck_assert_int_eq(self_count, 0);
 }
 END_TEST

--- a/src/test/unit/unit_tests_tcp_state.c
+++ b/src/test/unit/unit_tests_tcp_state.c
@@ -1645,7 +1645,67 @@ START_TEST(test_icmp_try_deliver_tcp_error_port_unreach_syn_sent_closes)
     memset(ts, 0, sizeof(*ts));
     ts->proto = WI_IPPROTO_TCP;
     ts->S = &s;
-    ts->sock.tcp.state = TCP_SYN_SENT;
+    ts->sock.tcp.state   = TCP_SYN_SENT;
+    ts->sock.tcp.seq     = 0xDEADBEEFU;   /* ISS */
+    ts->sock.tcp.snd_una = 0xDEADBEEFU;
+    ts->local_ip  = 0x0A000001U;
+    ts->remote_ip = 0x0A000064U;
+    ts->src_port  = 54321;
+    ts->dst_port  = 443;
+    fifo_init(&ts->sock.tcp.txbuf, ts->txmem, TXBUF_SIZE);
+
+    memset(buf, 0, sizeof(buf));
+    icmp->ip.len = ee16((uint16_t)(sizeof(buf) - ETH_HEADER_LEN));
+    icmp->type   = ICMP_DEST_UNREACH;
+    icmp->code   = ICMP_PORT_UNREACH;
+
+    orig_ip = (struct wolfIP_ip_wire *)(buf + sizeof(struct wolfIP_icmp_packet));
+    orig_ip->ver_ihl = 0x45;
+    orig_ip->proto   = WI_IPPROTO_TCP;
+    orig_ip->src     = ee32(ts->local_ip);
+    orig_ip->dst     = ee32(ts->remote_ip);
+
+    orig_tcp_hdr = (uint8_t *)orig_ip + IP_HEADER_LEN;
+    sp = ee16(ts->src_port);
+    dp = ee16(ts->dst_port);
+    memcpy(orig_tcp_hdr,     &sp, 2);
+    memcpy(orig_tcp_hdr + 2, &dp, 2);
+    /* RFC 5927 4.1: embedded SEG.SEQ is the in-flight SYN (== ISS == snd_una),
+     * so it falls inside the [snd_una, snd_una+1) send window. */
+    {
+        uint32_t emb_seq = ee32(ts->sock.tcp.seq);
+        memcpy(orig_tcp_hdr + 4, &emb_seq, 4);
+    }
+
+    icmp_try_deliver_tcp_error(&s, icmp);
+
+    /* PORT_UNREACH on SYN_SENT with an in-window seq must close the socket */
+    ck_assert_int_eq(ts->proto, 0);
+}
+END_TEST
+
+START_TEST(test_icmp_try_deliver_tcp_error_port_unreach_bad_seq_ignored)
+{
+    struct wolfIP s;
+    struct tsocket *ts;
+    uint8_t buf[sizeof(struct wolfIP_icmp_packet) + IP_HEADER_LEN + 8];
+    struct wolfIP_icmp_packet *icmp = (struct wolfIP_icmp_packet *)buf;
+    struct wolfIP_ip_wire *orig_ip;
+    uint8_t *orig_tcp_hdr;
+    uint16_t sp, dp;
+    uint32_t bad_seq;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+
+    ts = &s.tcpsockets[0];
+    memset(ts, 0, sizeof(*ts));
+    ts->proto = WI_IPPROTO_TCP;
+    ts->S = &s;
+    ts->sock.tcp.state   = TCP_SYN_SENT;
+    ts->sock.tcp.seq     = 0xDEADBEEFU;   /* ISS */
+    ts->sock.tcp.snd_una = 0xDEADBEEFU;
     ts->local_ip  = 0x0A000001U;
     ts->remote_ip = 0x0A000064U;
     ts->src_port  = 54321;
@@ -1669,10 +1729,14 @@ START_TEST(test_icmp_try_deliver_tcp_error_port_unreach_syn_sent_closes)
     memcpy(orig_tcp_hdr,     &sp, 2);
     memcpy(orig_tcp_hdr + 2, &dp, 2);
 
+    /* seq far outside [snd_una, snd_una+1) */
+    bad_seq = ee32(0x41414141U);
+    memcpy(orig_tcp_hdr + 4, &bad_seq, 4);
+
     icmp_try_deliver_tcp_error(&s, icmp);
 
-    /* PORT_UNREACH on SYN_SENT must close the socket */
-    ck_assert_int_eq(ts->proto, 0);
+    /* Out-of-window seq: socket must NOT be closed */
+    ck_assert_int_ne(ts->proto, 0);
 }
 END_TEST
 

--- a/src/test/unit/unit_wolfguard.c
+++ b/src/test/unit/unit_wolfguard.c
@@ -2067,6 +2067,61 @@ START_TEST(test_allowed_ip_source_rejected)
 END_TEST
 
 /*
+ * wolfguard_output (the wg0 TX dispatch) must reject frames whose IP version
+ * nibble is not 4.  wolfguard is IPv4-only (wg_allowedips_lookup keys on a
+ * uint32_t), and the destination-address read at offset 16 is only meaningful
+ * for an IPv4 header.  A raw or packet socket bound to wg0 (WOLFIP_RAWSOCKETS /
+ * WOLFIP_PACKET_SOCKETS) can hand an arbitrary frame to wolfguard_output; with
+ * no version check a non-IPv4 frame is misparsed as IPv4 and queued for
+ * encryption to whichever peer happens to match the four bytes at offset 16.
+ */
+START_TEST(test_output_rejects_non_ipv4)
+{
+    struct wg_device dev;
+    uint8_t frame[32];
+    const uint8_t bad_versions[] = { 0x00, 0x50, 0x60, 0xF0 }; /* not IPv4 */
+    size_t i;
+    int ret;
+
+    memset(&dev, 0, sizeof(dev));
+
+    /* Peer 0 owns 10.0.0.0/24 and is active but has no session, so any packet
+     * that reaches wg_packet_send is staged rather than encrypted. */
+    ck_assert_int_eq(wg_allowedips_insert(&dev, ee32(0x0A000000), 24, 0), 0);
+    dev.peers[0].is_active = 1;
+    /* A non-zeroed handshake state keeps wg_packet_send's staging branch from
+     * initiating a handshake, which would reach for the (absent) UDP socket. */
+    dev.peers[0].handshake.state = WG_HANDSHAKE_CREATED_INITIATION;
+
+    /* Each frame carries dest 10.0.0.2 at offset 16 -- a match for peer 0 --
+     * so the only thing standing between it and the send path is the version
+     * check.  staged_count stays 0 only if the frame is dropped first. */
+    for (i = 0; i < sizeof(bad_versions); i++) {
+        memset(frame, 0, sizeof(frame));
+        frame[0] = bad_versions[i];
+        frame[16] = 10; frame[17] = 0; frame[18] = 0; frame[19] = 2;
+
+        dev.peers[0].staged_count = 0;
+        ret = wolfguard_output(&dev, frame, sizeof(frame));
+
+        ck_assert_int_eq(ret, -1);
+        ck_assert_uint_eq(dev.peers[0].staged_count, 0);
+    }
+
+    /* Positive control: a well-formed IPv4 frame to the same destination is
+     * accepted and reaches the send path (staged, since there is no session). */
+    memset(frame, 0, sizeof(frame));
+    frame[0] = 0x45; /* IPv4, IHL=5 */
+    frame[16] = 10; frame[17] = 0; frame[18] = 0; frame[19] = 2;
+
+    dev.peers[0].staged_count = 0;
+    ret = wolfguard_output(&dev, frame, sizeof(frame));
+    ck_assert_int_eq(ret, 0);
+    ck_assert_uint_eq(dev.peers[0].staged_count, 1);
+}
+END_TEST
+
+/*
  * Test suite assembly
  * */
 
@@ -2142,6 +2197,7 @@ static Suite *wolfguard_suite(void)
     tcase_add_test(tc, test_staged_packets_zeroed_after_send);
     tcase_add_test(tc, test_keepalive_rejected_expired_key);
     tcase_add_test(tc, test_allowed_ip_source_rejected);
+    tcase_add_test(tc, test_output_rejects_non_ipv4);
     suite_add_tcase(s, tc);
 
     /* Timer logic (condition checks) */

--- a/src/test/unit/unit_wolfguard.c
+++ b/src/test/unit/unit_wolfguard.c
@@ -748,6 +748,62 @@ START_TEST(test_cookie_reply)
 END_TEST
 
 /*
+ * a default-initialized cookie secret must never validate a mac2.
+ */
+START_TEST(test_cookie_zero_secret_no_mac2_bypass)
+{
+    struct wg_device dev;
+    struct wg_peer peer;
+    struct wg_msg_initiation msg;
+    enum wg_cookie_mac_state state;
+    size_t mac_off;
+    uint32_t src_ip = 0x0A0A0A01;
+    uint16_t src_port = 12345;
+    uint8_t zero_secret[WG_HASH_LEN];
+    uint8_t src_data[6];
+    uint8_t forged_cookie[WG_COOKIE_LEN];
+
+    init_test_rng();
+
+    memset(&dev, 0, sizeof(dev));
+    memset(&peer, 0, sizeof(peer));
+
+    wg_dh_generate(dev.static_private, dev.static_public, &test_rng);
+
+    /* Default-initialized checker: secret all-zero, birthdate 0 */
+    wg_cookie_checker_init(&dev.cookie_checker, dev.static_public);
+
+    /* Build an initiation with a valid mac1 (the mac1 key derives from the
+     * device public key, which the attacker knows) and an initially zero mac2 */
+    memcpy(peer.public_key, dev.static_public, WG_PUBLIC_KEY_LEN);
+    wg_cookie_init(&peer.cookie, dev.static_public);
+
+    memset(&msg, 0xAA, sizeof(msg));
+    mac_off = offsetof(struct wg_msg_initiation, macs);
+    ck_assert_int_eq(wg_cookie_add_macs(&peer, &msg, sizeof(msg), mac_off), 0);
+
+    /* Forge mac2 from the known all-zero secret, exactly as validate() would
+     * derive the cookie for this source */
+    memset(zero_secret, 0, sizeof(zero_secret));
+    memcpy(src_data, &src_ip, 4);
+    src_data[4] = (uint8_t)(src_port);
+    src_data[5] = (uint8_t)(src_port >> 8);
+    ck_assert_int_eq(wg_mac(forged_cookie, zero_secret, WG_HASH_LEN,
+                            src_data, sizeof(src_data)), 0);
+    ck_assert_int_eq(wg_mac(msg.macs.mac2, forged_cookie, WG_COOKIE_LEN,
+                            (uint8_t *)&msg, mac_off + WG_COOKIE_LEN), 0);
+
+    /* Boot-relative now: small ms-since-boot, within the freshness window */
+    state = wg_cookie_validate(&dev.cookie_checker, &msg, sizeof(msg),
+                               mac_off, src_ip, src_port, 5000);
+
+    /* The forged mac2 must NOT be accepted: a never-generated secret may never
+     * yield VALID_WITH_COOKIE (which would bypass under-load enforcement). */
+    ck_assert_int_ne(state, WG_COOKIE_MAC_VALID_WITH_COOKIE);
+}
+END_TEST
+
+/*
  * Allowed IPs (wg_allowedips.c)
  * */
 
@@ -2165,6 +2221,7 @@ static Suite *wolfguard_suite(void)
     tcase_add_test(tc, test_cookie_mac1_valid);
     tcase_add_test(tc, test_cookie_mac1_invalid);
     tcase_add_test(tc, test_cookie_reply);
+    tcase_add_test(tc, test_cookie_zero_secret_no_mac2_bypass);
     tcase_add_test(tc, test_cookie_enforcement_under_load);
     tcase_add_test(tc, test_response_under_load_threshold);
     suite_add_tcase(s, tc);

--- a/src/test/unit/unit_wolfguard.c
+++ b/src/test/unit/unit_wolfguard.c
@@ -1695,6 +1695,49 @@ START_TEST(test_cookie_enforcement_under_load)
 }
 END_TEST
 
+/* Response-path load accounting must trip under_load. */
+START_TEST(test_response_under_load_threshold)
+{
+    struct wg_device dev_a, dev_b;
+    struct wg_peer peer_a, peer_b;
+    struct wg_msg_initiation init_msg;
+    struct wg_msg_response resp_msg;
+    struct wg_peer *found;
+    size_t mac_off;
+    int i;
+
+    setup_paired_devices(&dev_a, &dev_b, &peer_a, &peer_b);
+
+    dev_a.now = 20000;
+    dev_b.now = 20000;
+    wg_noise_handshake_init(&peer_a.handshake, dev_a.static_private,
+                            dev_b.static_public, NULL, &dev_a.rng);
+    ck_assert_int_eq(wg_noise_create_initiation(&dev_a, &peer_a, &init_msg), 0);
+    mac_off = offsetof(struct wg_msg_initiation, macs);
+    wg_cookie_add_macs(&peer_a, &init_msg, sizeof(init_msg), mac_off);
+
+    found = wg_noise_consume_initiation(&dev_b, &init_msg);
+    ck_assert_ptr_nonnull(found);
+    ck_assert_int_eq(wg_noise_create_response(&dev_b, found, &resp_msg), 0);
+
+    resp_msg.receiver_index = 0xDEADBEEFu;
+    mac_off = offsetof(struct wg_msg_response, macs);
+    wg_cookie_add_macs(found, &resp_msg, sizeof(resp_msg), mac_off);
+
+    wolfguard_poll(&dev_a, 30000);
+    ck_assert_int_eq(dev_a.under_load, 0);
+
+    for (i = 0; i < WOLFGUARD_MAX_PEERS; i++) {
+        wg_packet_receive(&dev_a, (const uint8_t *)&resp_msg, sizeof(resp_msg),
+                          ee32(0xC0A80105), ee16(40000));
+    }
+    ck_assert_int_eq(dev_a.handshakes_per_cycle, WOLFGUARD_MAX_PEERS);
+
+    wolfguard_poll(&dev_a, 40000);
+    ck_assert_int_eq(dev_a.under_load, 1);
+}
+END_TEST
+
 /* PSK survives rekey */
 START_TEST(test_psk_survives_rekey)
 {
@@ -2068,6 +2111,7 @@ static Suite *wolfguard_suite(void)
     tcase_add_test(tc, test_cookie_mac1_invalid);
     tcase_add_test(tc, test_cookie_reply);
     tcase_add_test(tc, test_cookie_enforcement_under_load);
+    tcase_add_test(tc, test_response_under_load_threshold);
     suite_add_tcase(s, tc);
 
     /* Allowed IPs */

--- a/src/wolfguard/wg_cookie.c
+++ b/src/wolfguard/wg_cookie.c
@@ -26,6 +26,9 @@ void wg_cookie_checker_init(struct wg_cookie_checker *checker,
 {
     memset(checker, 0, sizeof(*checker));
 
+    checker->secret_birthdate = (UINT64_MAX -
+            (uint64_t)WG_COOKIE_SECRET_MAX_AGE * 1000UL - 1);
+
     wg_hash2(checker->message_mac1_key,
              (const uint8_t *)WG_LABEL_MAC1, strlen(WG_LABEL_MAC1),
              device_public_key, WG_PUBLIC_KEY_LEN);

--- a/src/wolfguard/wg_packet.c
+++ b/src/wolfguard/wg_packet.c
@@ -475,8 +475,6 @@ static void wg_handle_initiation(struct wg_device *dev, const uint8_t *data,
         return;
     }
 
-    dev->handshakes_per_cycle++;
-
     /* Under load: require valid cookie (mac2) or send cookie reply */
     if (dev->under_load && mac_state != WG_COOKIE_MAC_VALID_WITH_COOKIE) {
         struct wg_msg_cookie cookie_reply;
@@ -496,6 +494,8 @@ static void wg_handle_initiation(struct wg_device *dev, const uint8_t *data,
         }
         return;
     }
+
+    dev->handshakes_per_cycle++;
 
     /* Consume initiation */
     peer = wg_noise_consume_initiation(dev, msg);
@@ -561,8 +561,6 @@ static void wg_handle_response(struct wg_device *dev, const uint8_t *data,
         return;
     }
 
-    dev->handshakes_per_cycle++;
-
     /* Under load: require valid cookie (mac2) or send cookie reply */
     if (dev->under_load && mac_state != WG_COOKIE_MAC_VALID_WITH_COOKIE) {
         struct wg_msg_cookie cookie_reply;
@@ -582,6 +580,8 @@ static void wg_handle_response(struct wg_device *dev, const uint8_t *data,
         }
         return;
     }
+
+    dev->handshakes_per_cycle++;
 
     /* Find peer by receiver_index (our sender_index from initiation) */
     receiver_index = wg_le32_decode(msg->receiver_index);

--- a/src/wolfguard/wolfguard.c
+++ b/src/wolfguard/wolfguard.c
@@ -263,7 +263,7 @@ int wolfguard_output(struct wg_device *dev, const uint8_t *packet, size_t len)
 void wolfguard_poll(struct wg_device *dev, uint64_t now_ms)
 {
     dev->now = now_ms;
-    dev->under_load = (dev->handshakes_per_cycle > WOLFGUARD_MAX_PEERS);
+    dev->under_load = (dev->handshakes_per_cycle >= WOLFGUARD_MAX_PEERS);
     dev->handshakes_per_cycle = 0;
     wg_timers_tick(dev, now_ms);
 }

--- a/src/wolfguard/wolfguard.c
+++ b/src/wolfguard/wolfguard.c
@@ -242,6 +242,9 @@ int wolfguard_output(struct wg_device *dev, const uint8_t *packet, size_t len)
     if (len < 20)
         return -1; /* Too short for IPv4 header */
 
+    if ((packet[0] >> 4) != 4)
+        return -1;
+
     /* Extract destination IP from IPv4 header (offset 16) */
     memcpy(&dst_ip, packet + 16, 4);
 

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -7592,6 +7592,9 @@ static int dhcp_msg_type(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_le
 {
     uint8_t *opt = (uint8_t *)msg->options;
     uint8_t *opt_end;
+    int msg_type = -1;
+    int saw_server_id = 0;
+    uint32_t server_id = 0;
     if (msg_len < DHCP_HEADER_LEN)
         return -1;
     if (ee32(msg->magic) != DHCP_MAGIC)
@@ -7618,11 +7621,20 @@ static int dhcp_msg_type(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_le
         len = opt[1];
         if (opt + 2 + len > opt_end)
             break;
-        if (code == DHCP_OPTION_MSG_TYPE && len == 1)
-            return opt[2];
+        if (code == DHCP_OPTION_MSG_TYPE && len == 1) {
+            msg_type = opt[2];
+        } else if (code == DHCP_OPTION_SERVER_ID && len >= 4) {
+            server_id = DHCP_OPT_data_to_u32((struct dhcp_option *)opt);
+            saw_server_id = 1;
+        }
         opt += 2 + len;
     }
-    return -1;
+    /* Reject a reply that does not carry the server identifier of the
+     * server we committed to during the OFFER phase. */
+    if (s->dhcp_server_ip != 0 &&
+        (!saw_server_id || server_id != s->dhcp_server_ip))
+        return -1;
+    return msg_type;
 }
 
 static int dhcp_parse_ack(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_len)
@@ -8282,11 +8294,6 @@ static void arp_recv(struct wolfIP *s, unsigned int if_idx, void *buf, int len)
                     if (memcmp(s->arp.neighbors[idx].mac, sender_mac, 6) == 0)
                         s->arp.neighbors[idx].ts = s->last_tick;
                 }
-                /* Do not learn a new neighbor from an unsolicited REQUEST:
-                 * a same-LAN attacker can spoof sip to match an outstanding pending request and install
-                 * a forged MAC that then locks out the genuine reply. Only REPLYs
-                 * populate new cache entries; the pending slot is left intact so the genuine
-                 * reply still resolves. */
             }
         }
         eth_output_add_header(s, if_idx, arp->tma, &arp->eth, ETH_TYPE_ARP);

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -2148,6 +2148,8 @@ void wolfIP_register_callback(struct wolfIP *s, int sock_fd, tsocket_cb cb,
                               void *arg)
 {
     struct tsocket *t;
+    if (!s)
+        return;
     if (sock_fd < 0)
         return;
     if (IS_SOCKET_TCP(sock_fd)) {

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -2563,8 +2563,21 @@ static void icmp_try_deliver_tcp_error(struct wolfIP *s,
             } else if (icmp->code == ICMP_PROT_UNREACH ||
                     icmp->code == ICMP_PORT_UNREACH) {
                 if (t->sock.tcp.state == TCP_SYN_SENT ||
-                        t->sock.tcp.state == TCP_SYN_RCVD)
-                    close_socket(t);
+                        t->sock.tcp.state == TCP_SYN_RCVD) {
+                    uint32_t emb_seq, snd_nxt;
+
+                    /* RFC 5927 4.1: only honour the error if the embedded
+                     * SEG.SEQ lies within the send window [SND.UNA, SND.NXT).
+                     * In SYN_SENT/SYN_RCVD the lone in-flight segment is the
+                     * SYN(-ACK), occupying exactly snd_una (seq is not yet
+                     * advanced here), so SND.NXT == snd_una + 1. */
+                    memcpy(&emb_seq, orig_tcp + 4, sizeof(emb_seq));
+                    emb_seq = ee32(emb_seq);
+                    snd_nxt = tcp_seq_inc(t->sock.tcp.snd_una, 1);
+                    if (tcp_seq_leq(t->sock.tcp.snd_una, emb_seq) &&
+                            tcp_seq_lt(emb_seq, snd_nxt))
+                        close_socket(t);
+                }
             }
         }
         break;

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -7783,15 +7783,24 @@ static int dhcp_poll(struct wolfIP *s)
 
 static int dhcp_send_request(struct wolfIP *s)
 {
+
     struct dhcp_msg req;
     struct dhcp_option *opt = (struct dhcp_option *)(req.options);
     struct wolfIP_sockaddr_in sin;
     struct ipconf *primary = wolfIP_primary_ipconf(s);
-    uint64_t retry_at = s ? (s->last_tick + 1U) : 0;
-    int renewing = (s->dhcp_state == DHCP_RENEWING);
-    int rebinding = (s->dhcp_state == DHCP_REBINDING);
+    uint64_t retry_at = 0;
+    int renewing = 0;
+    int rebinding = 0;
     int ret;
     uint32_t opt_sz = 0;
+
+    if (!s)
+        return -1;
+
+    retry_at = s ? (s->last_tick + 1U) : 0;
+    renewing = (s->dhcp_state == DHCP_RENEWING);
+    rebinding = (s->dhcp_state == DHCP_REBINDING);
+
     /* Prepare DHCP request */
     memset(&req, 0, sizeof(struct dhcp_msg));
     req.op = BOOT_REQUEST;

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -9406,6 +9406,9 @@ int wolfIP_poll(struct wolfIP *s, uint64_t now)
     struct wolfIP_timer tmr;
     memset(buf, 0, LINK_MTU);
 
+    if (!s)
+        return -WOLFIP_EINVAL;
+
     s->last_tick = now;
 
     /* Step 1: Poll the device */

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8257,14 +8257,12 @@ static void arp_recv(struct wolfIP *s, unsigned int if_idx, void *buf, int len)
                 if (idx >= 0) {
                     if (memcmp(s->arp.neighbors[idx].mac, sender_mac, 6) == 0)
                         s->arp.neighbors[idx].ts = s->last_tick;
-                } else if (arp_pending_match_and_clear(s, if_idx, sip)) {
-                    /* Only learn from an unsolicited request when we have an
-                     * outstanding ARP request for this peer; otherwise a
-                     * same-LAN attacker can flood requests from distinct
-                     * sender IP/MAC pairs to exhaust the neighbor table and
-                     * lock out legitimate replies until ARP_AGING_TIMEOUT_MS. */
-                    arp_store_neighbor(s, if_idx, sip, sender_mac);
                 }
+                /* Do not learn a new neighbor from an unsolicited REQUEST:
+                 * a same-LAN attacker can spoof sip to match an outstanding pending request and install
+                 * a forged MAC that then locks out the genuine reply. Only REPLYs
+                 * populate new cache entries; the pending slot is left intact so the genuine
+                 * reply still resolves. */
             }
         }
         eth_output_add_header(s, if_idx, arp->tma, &arp->eth, ETH_TYPE_ARP);


### PR DESCRIPTION
c33f76c - validate the dhcp server-id in dhcp_msg_type so a forged dhcpnak with an absent or mismatched server identifier can no longer deconfigure the lease this pretty much mirrors the guard already in dhcp_parse_ack
3ae5ec9 - validate the tcp sequence number against the half-open send window before honouring an icmp port/prot_unreach
b197590 scope http percent-decoding to the request target so an encoded CRLF in a header value can no longer inject headers or smuggle body
2dcf41a - initialize the secret_birthdate so that the mac2 is not forgeable (it was up until 120s before refresh) initializing it with (UINT64_MAX - (uint64_t)WG_COOKIE_SECRET_MAX_AGE * 1000UL - 1)
349d1f2 - add missing ipv4 correcteness check (nibble must be 4)
8710a1d - add missing null guard in dhcp_send_request
7558e58 - add missing null check in wolfip_poll
4bdeea6 - add missing null check in wolfip_register_callback
7955e6d - prevent arp cache poisoning by no longer learning neighbors from arp requests now only relipes will populate the cache and update the affected arp unit tests to match
e31c232 - move the dev->handshakes_per_cycle increment (counts how many handshakes per poll cycle) after the dos guard flag (under_load) - change the poll to check if under_load to include 8 max peers (from >   to >=)
