### PR TITLE
test: zero-initialize sin in sendto error-path test (fix macOS build)

### DIFF
--- a/src/test/unit/unit_tests_dns_dhcp.c
+++ b/src/test/unit/unit_tests_dns_dhcp.c
@@ -1114,7 +1114,9 @@ START_TEST(test_sock_sendto_more_error_paths)
     int udp_sd;
     int icmp_sd;
     struct tsocket *ts;
-    struct wolfIP_sockaddr_in sin;
+    /* Zero-initialized: this error-path test passes &sin into sendto without
+     * filling it, which newer clang flags under -Wuninitialized-const-pointer. */
+    struct wolfIP_sockaddr_in sin = {0};
     uint8_t buf[64];
     uint8_t tiny[128];
     uint8_t tiny_udp[32];


### PR DESCRIPTION
The macOS interop CI job (Apple clang) failed to build the unit suite.

Zero-initialize sin so the diagnostic no longer fires. The test outcome is unchanged. Reproduced and verified with clang 21 and -std=gnu23, which matches the macOS runner; gcc was always clean.