### PR TITLE
ARP: improve policies, guards and neighbors cache. Fix related Fenrir claims.

### DIFF
--- a/.github/workflows/stm32h563-m33mu.yml
+++ b/.github/workflows/stm32h563-m33mu.yml
@@ -85,6 +85,20 @@ jobs:
             tail -n 200 /tmp/m33mu.log || true
             exit 1
           fi
+          # The host grants the lease at the DHCP ACK, but the device may
+          # still be running RFC 4331 DAD (3 probes) before it binds and
+          # starts serving. Under the emulated tick rate that window is
+          # several seconds, longer than the nc retry burst below. Wait for
+          # the app's own ready line (bounded; apps without the marker keep
+          # the old behavior).
+          if grep -q "Starting DHCP client" /tmp/m33mu.log 2>/dev/null; then
+            for _ in $(seq 1 60); do
+              if grep -q "DHCP configuration received" /tmp/m33mu.log 2>/dev/null; then
+                break
+              fi
+              sleep 1
+            done
+          fi
           echo "Leased IP: ${ip}"
 
           ok=0
@@ -207,6 +221,17 @@ jobs:
             echo "No DHCP lease acquired."
             tail -n 200 /tmp/m33mu.log || true
             exit 1
+          fi
+          # The host grants the lease at the DHCP ACK, but the device may
+          # still be running RFC 4331 DAD (3 probes) before it binds and
+          # starts serving. Wait for the app's own ready line (bounded).
+          if grep -q "Starting DHCP client" /tmp/m33mu.log 2>/dev/null; then
+            for _ in $(seq 1 60); do
+              if grep -q "DHCP configuration received" /tmp/m33mu.log 2>/dev/null; then
+                break
+              fi
+              sleep 1
+            done
           fi
           echo "Leased IP: ${ip}"
 
@@ -422,6 +447,17 @@ jobs:
             echo "m33mu log:"
             tail -n 200 /tmp/m33mu.log || true
             exit 1
+          fi
+          # The host grants the lease at the DHCP ACK, but the device may
+          # still be running RFC 4331 DAD (3 probes) before it binds and
+          # starts serving. Wait for the app's own ready line (bounded).
+          if grep -q "Starting DHCP client" /tmp/m33mu.log 2>/dev/null; then
+            for _ in $(seq 1 60); do
+              if grep -q "DHCP configuration received" /tmp/m33mu.log 2>/dev/null; then
+                break
+              fi
+              sleep 1
+            done
           fi
           echo "Leased IP: ${ip}"
 

--- a/Makefile
+++ b/Makefile
@@ -830,6 +830,7 @@ UNIT_TEST_SRCS:=src/test/unit/unit.c \
 	src/test/unit/unit_tests_poll_dispatcher.c \
 	src/test/unit/unit_tests_dhcp_edges.c \
 	src/test/unit/unit_tests_ip_arp_recv.c \
+	src/test/unit/unit_tests_arp_regression.c \
 	src/test/unit/unit_tests_dns_edges.c \
 	src/test/unit/unit_tests_misc_edges.c \
 	src/test/unit/unit_tests_vlan.c

--- a/src/port/stm32h563/main.c
+++ b/src/port/stm32h563/main.c
@@ -1043,7 +1043,12 @@ int main(void)
         uint32_t dhcp_timeout;
         int dhcp_ret;
 
-        dhcp_timeout = 5000;  /* safety-net tick timeout */
+        /* Safety-net tick timeout. Must cover the worst case: server
+         * OFFER delivery delay (host ARP chicken-and-egg, up to ~3s) +
+         * RFC 4331 DAD (3 probes, ~3s after the ACK). 5000 was too
+         * tight once DAD landed and the device fell back to the static
+         * IP while the test still pinged the leased one. */
+        dhcp_timeout = 10000;
 
         uart_puts("Starting DHCP client...\n");
         dhcp_ret = dhcp_client_init(IPStack);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -34,6 +34,7 @@
 #include "unit_tests_poll_dispatcher.c"
 #include "unit_tests_dhcp_edges.c"
 #include "unit_tests_ip_arp_recv.c"
+#include "unit_tests_arp_regression.c"
 #include "unit_tests_dns_edges.c"
 #include "unit_tests_misc_edges.c"
 #include "unit_tests_vlan.c"
@@ -1427,6 +1428,11 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_arp_recv_reply_multicast_sma_dropped);
     tcase_add_test(tc_core, test_arp_recv_request_broadcast_sma_dropped);
     tcase_add_test(tc_core, test_arp_recv_request_multicast_sma_dropped);
+    tcase_add_test(tc_core, test_regression_unsolicited_reply_first_install_dropped);
+    tcase_add_test(tc_core, test_regression_gratuitous_reply_zero_tip_dropped);
+    tcase_add_test(tc_core, test_regression_unsolicited_reply_gateway_not_poisoned);
+    tcase_add_test(tc_core, test_regression_owner_correction_requires_our_request);
+    tcase_add_test(tc_core, test_regression_unsolicited_reply_overwrite_still_blocked);
     tcase_add_test(tc_core, test_arp_recv_request_replies_but_reply_caches_neighbor);
     tcase_add_test(tc_core, test_arp_recv_forged_request_cannot_poison_pending);
     tcase_add_test(tc_core, test_arp_recv_runt_packet_dropped);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1408,6 +1408,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_dad_own_mac_reply_ignored);
     tcase_add_test(tc_core, test_dhcp_dad_reply_for_other_ip_ignored);
     tcase_add_test(tc_core, test_dhcp_dad_single_dhcp_timer_in_heap);
+    tcase_add_test(tc_core, test_dhcp_dad_probe_count_len_returning_driver);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_not_yet_rebind_sends_request);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_past_rebind_transitions_to_rebinding);
     tcase_add_test(tc_core, test_dhcp_timer_cb_rebinding_not_expired_sends_request);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1409,6 +1409,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_dad_reply_for_other_ip_ignored);
     tcase_add_test(tc_core, test_dhcp_dad_single_dhcp_timer_in_heap);
     tcase_add_test(tc_core, test_dhcp_dad_probe_count_len_returning_driver);
+    tcase_add_test(tc_core, test_dhcp_decline_wire_format);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_not_yet_rebind_sends_request);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_past_rebind_transitions_to_rebinding);
     tcase_add_test(tc_core, test_dhcp_timer_cb_rebinding_not_expired_sends_request);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1390,6 +1390,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_dad_conflict_releases_and_rediscover);
     tcase_add_test(tc_core, test_dhcp_dad_own_mac_reply_ignored);
     tcase_add_test(tc_core, test_dhcp_dad_reply_for_other_ip_ignored);
+    tcase_add_test(tc_core, test_dhcp_dad_single_dhcp_timer_in_heap);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_not_yet_rebind_sends_request);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_past_rebind_transitions_to_rebinding);
     tcase_add_test(tc_core, test_dhcp_timer_cb_rebinding_not_expired_sends_request);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1088,6 +1088,8 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_arp_recv_request_refreshes_existing_neighbor);
     tcase_add_test(tc_core, test_arp_recv_reply_overwrite_blocked_when_no_pending);
     tcase_add_test(tc_core, test_arp_request_rate_limited);
+    tcase_add_test(tc_core, test_arp_request_first_not_rate_limited);
+    tcase_add_test(tc_core, test_arp_tick_restart_resets_rate_limit);
 #ifdef IP_MULTICAST
     tcase_add_test(tc_core, test_close_releases_multicast);
 #endif

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -780,6 +780,9 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_proto, test_arp_pending_record_prefers_empty_slot);
     tcase_add_test(tc_proto, test_arp_pending_match_and_clear_time_goes_back);
     tcase_add_test(tc_proto, test_arp_store_neighbor_no_space);
+    tcase_add_test(tc_proto, test_arp_full_table_solicited_reply_installs_via_eviction);
+    tcase_add_test(tc_proto, test_arp_lookup_refreshes_ts_use_based_aging);
+    tcase_add_test(tc_proto, test_arp_aging_exact_boundary);
     tcase_add_test(tc_proto, test_arp_store_neighbor_null_stack);
     tcase_add_test(tc_proto, test_arp_lookup_if_idx_mismatch);
     tcase_add_test(tc_proto, test_arp_request_missing_conf);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1386,6 +1386,10 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_parse_ack_with_renewal_and_rebind_times);
     tcase_add_test(tc_core, test_dhcp_parse_ack_dns_already_set_skipped);
     tcase_add_test(tc_core, test_dhcp_parse_ack_inner_pad_bytes_skipped);
+    tcase_add_test(tc_core, test_dhcp_dad_probe_wire_format);
+    tcase_add_test(tc_core, test_dhcp_dad_conflict_releases_and_rediscover);
+    tcase_add_test(tc_core, test_dhcp_dad_own_mac_reply_ignored);
+    tcase_add_test(tc_core, test_dhcp_dad_reply_for_other_ip_ignored);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_not_yet_rebind_sends_request);
     tcase_add_test(tc_core, test_dhcp_timer_cb_renewing_past_rebind_transitions_to_rebinding);
     tcase_add_test(tc_core, test_dhcp_timer_cb_rebinding_not_expired_sends_request);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -938,6 +938,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_proto, test_regression_loopback_udp_tx_backpressure_retries_after_queue_drain);
     tcase_add_test(tc_proto, test_regression_ll_send_frame_returns_wolfip_error_codes);
     tcase_add_test(tc_proto, test_regression_loopback_ack_retry_pending_requeued_on_poll);
+    tcase_add_test(tc_proto, test_regression_pure_ack_arp_miss_schedules_retry);
     tcase_add_test(tc_proto, test_regression_loopback_queue_full_pure_ack_backpressure_retry);
     tcase_add_test(tc_proto, test_regression_tcp_tx_desc_payload_len_keeps_descriptor_layout_sanity);
     tcase_add_test(tc_proto, test_regression_fast_recovery_cwnd_ssthresh_rfc5681);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1258,6 +1258,9 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_tcp_input_window_grows_from_zero_stops_persist);
     tcase_add_test(tc_core, test_tcp_rto_cb_fin_wait_2_timeout_closes_socket);
     tcase_add_test(tc_core, test_accept_synack_retransmit_repeats_isn);
+    tcase_add_test(tc_core, test_accept_clears_listener_tx_fifo);
+    tcase_add_test(tc_core, test_rst_listener_fallback_clears_tx_fifo);
+    tcase_add_test(tc_core, test_no_stale_synack_after_accept_new_conn);
     tcase_add_test(tc_core, test_tcp_rto_cb_fin_wait_2_wrong_state_stops_timer);
     tcase_add_test(tc_core, test_tcp_rto_cb_ctrl_not_needed_stops);
     tcase_add_test(tc_core, test_tcp_rto_cb_ctrl_maxretries_nonlistener_closes);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1436,6 +1436,10 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_regression_unsolicited_reply_gateway_not_poisoned);
     tcase_add_test(tc_core, test_regression_owner_correction_requires_our_request);
     tcase_add_test(tc_core, test_regression_unsolicited_reply_overwrite_still_blocked);
+    tcase_add_test(tc_core, test_regression_syn_source_does_not_install_neighbor);
+    tcase_add_test(tc_core, test_regression_syn_source_does_not_poison_gateway);
+    tcase_add_test(tc_core, test_regression_syn_source_not_resolved_for_tx);
+    tcase_add_test(tc_core, test_regression_syn_learned_only_via_arp_exchange);
     tcase_add_test(tc_core, test_arp_recv_request_replies_but_reply_caches_neighbor);
     tcase_add_test(tc_core, test_arp_recv_forged_request_cannot_poison_pending);
     tcase_add_test(tc_core, test_arp_recv_runt_packet_dropped);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -762,7 +762,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_proto, test_arp_queue_packet_same_dest_different_if);
     tcase_add_test(tc_proto, test_arp_queue_packet_uses_empty_slot);
     tcase_add_test(tc_proto, test_arp_queue_packet_drops_oversize_len);
-    tcase_add_test(tc_proto, test_arp_queue_packet_slot_fallback_zero);
+    tcase_add_test(tc_proto, test_arp_queue_packet_full_drops_new_dest);
     tcase_add_test(tc_proto, test_arp_flush_pending_no_neighbor);
     tcase_add_test(tc_proto, test_arp_flush_pending_len_zero_clears);
     tcase_add_test(tc_proto, test_arp_flush_pending_null_stack);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1423,6 +1423,10 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_arp_recv_reply_sender_multicast_rejected);
     tcase_add_test(tc_core, test_arp_recv_reply_sender_own_ip_rejected);
     tcase_add_test(tc_core, test_arp_recv_reply_sender_zero_ip_rejected);
+    tcase_add_test(tc_core, test_arp_recv_reply_broadcast_sma_dropped);
+    tcase_add_test(tc_core, test_arp_recv_reply_multicast_sma_dropped);
+    tcase_add_test(tc_core, test_arp_recv_request_broadcast_sma_dropped);
+    tcase_add_test(tc_core, test_arp_recv_request_multicast_sma_dropped);
     tcase_add_test(tc_core, test_arp_recv_request_replies_but_reply_caches_neighbor);
     tcase_add_test(tc_core, test_arp_recv_forged_request_cannot_poison_pending);
     tcase_add_test(tc_core, test_arp_recv_runt_packet_dropped);

--- a/src/test/unit/unit_shared.c
+++ b/src/test/unit/unit_shared.c
@@ -402,8 +402,10 @@ static void dhcp_test_complete_dad(struct wolfIP *s)
 {
     int iter = 0;
     while (s->dhcp_state == DHCP_DAD && iter < 16) {
+        /* Drive the real dispatch: handle_timers pops each fired timer,
+         * so the heap stays clean exactly as in production. */
         s->last_tick += DHCP_DAD_INTERVAL_MS;
-        dhcp_timer_cb(s);
+        handle_timers(s, s->last_tick);
         iter++;
     }
     ck_assert_int_eq(s->dhcp_state, DHCP_BOUND);

--- a/src/test/unit/unit_shared.c
+++ b/src/test/unit/unit_shared.c
@@ -394,6 +394,22 @@ void mock_link_init(struct wolfIP *s)
     mock_link_init_idx(s, idx, NULL);
 }
 
+/* Drive the RFC 4331 DAD state machine to completion (probes unanswered
+ * -> DHCP_BOUND) after a DHCPACK. Requires a working mock link so the
+ * probes can be sent. Bounded so a regression cannot hang the suite. */
+#ifdef ETHERNET
+static void dhcp_test_complete_dad(struct wolfIP *s)
+{
+    int iter = 0;
+    while (s->dhcp_state == DHCP_DAD && iter < 16) {
+        s->last_tick += DHCP_DAD_INTERVAL_MS;
+        dhcp_timer_cb(s);
+        iter++;
+    }
+    ck_assert_int_eq(s->dhcp_state, DHCP_BOUND);
+}
+#endif
+
 static struct timers_binheap heap;
 static void reset_heap(void) {
     heap.size = 0;

--- a/src/test/unit/unit_tests_arp_regression.c
+++ b/src/test/unit/unit_tests_arp_regression.c
@@ -223,6 +223,244 @@ START_TEST(test_regression_owner_correction_requires_our_request)
 END_TEST
 
 /* =========================================================================
+ * SYN-driven learning regression fixtures
+ *
+ * Derived from the wire-level PoCs of security-scan candidate
+ * candidate-3b4b443e774d63e8 (F-6035: unauthenticated neighbor learning
+ * from a TCP SYN's source / F-6036: gateway nexthop variant / F-9804 dup),
+ * inverted to assert the fixed behavior: a SYN installs nothing. The
+ * stack resolves the peer through the normal ARP exchange (request
+ * we sent, reply to it) when it transmits.
+ * ========================================================================= */
+
+/* Build a complete wire frame: Ethernet + IPv4 + TCP SYN, with valid IP
+ * and TCP checksums. Returns total frame length. */
+static uint32_t arp_regr_build_syn_frame(uint8_t *frame, const uint8_t *dst_mac,
+        const uint8_t *src_mac, ip4 src_ip, ip4 dst_ip, uint16_t dst_port)
+{
+    struct wolfIP_tcp_seg *tcp = (struct wolfIP_tcp_seg *)frame;
+    union transport_pseudo_header ph;
+
+    memset(frame, 0, ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN);
+    memcpy(tcp->ip.eth.dst, dst_mac, 6);
+    memcpy(tcp->ip.eth.src, src_mac, 6);
+    tcp->ip.eth.type = ee16(ETH_TYPE_IP);
+    tcp->ip.ver_ihl = 0x45;
+    tcp->ip.ttl = 64;
+    tcp->ip.proto = WI_IPPROTO_TCP;
+    tcp->ip.len = ee16(IP_HEADER_LEN + TCP_HEADER_LEN);
+    tcp->ip.src = ee32(src_ip);
+    tcp->ip.dst = ee32(dst_ip);
+    tcp->ip.csum = 0;
+    iphdr_set_checksum(&tcp->ip);
+
+    tcp->src_port = ee16(40000);
+    tcp->dst_port = ee16(dst_port);
+    tcp->seq = ee32(1);
+    tcp->ack = 0;
+    tcp->hlen = TCP_HEADER_LEN << 2; /* data offset 5, wire byte 0x50 */
+    tcp->flags = TCP_FLAG_SYN;
+    tcp->win = ee16(65535);
+    tcp->urg = 0;
+    tcp->csum = 0;
+
+    memset(&ph, 0, sizeof(ph));
+    ph.ph.src = tcp->ip.src;
+    ph.ph.dst = tcp->ip.dst;
+    ph.ph.proto = WI_IPPROTO_TCP;
+    ph.ph.len = ee16(TCP_HEADER_LEN);
+    tcp->csum = ee16(transport_checksum(&ph, &tcp->src_port));
+
+    return ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN;
+}
+
+/* Single-interface setup with a TCP listener on 10.0.0.1:1234.
+ * Returns the listener socket descriptor; ts points at its tsocket. */
+static int arp_regr_setup_listener(struct wolfIP *s, struct tsocket **ts)
+{
+    int listen_sd;
+    struct wolfIP_sockaddr_in sin;
+
+    arp_regr_setup(s);
+
+    listen_sd = wolfIP_sock_socket(s, AF_INET, IPSTACK_SOCK_STREAM, WI_IPPROTO_TCP);
+    ck_assert_int_gt(listen_sd, 0);
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = ee16(1234);
+    sin.sin_addr.s_addr = ee32(0x0A000001U);
+    ck_assert_int_eq(wolfIP_sock_bind(s, listen_sd,
+        (struct wolfIP_sockaddr *)&sin, sizeof(sin)), 0);
+    ck_assert_int_eq(wolfIP_sock_listen(s, listen_sd, 1), 0);
+    *ts = &s->tcpsockets[SOCKET_UNMARK(listen_sd)];
+    return listen_sd;
+}
+
+/* =========================================================================
+ * Regression (F-6035): a forged SYN from a directly-connected source IP
+ * is accepted but installs no neighbor entry. (PoC 1a, inverted.)
+ * ========================================================================= */
+START_TEST(test_regression_syn_source_does_not_install_neighbor)
+{
+    struct wolfIP s;
+    struct tsocket *ts;
+    uint8_t frame[ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN];
+    struct wolfIP_ll_dev *ll;
+    ip4 victim_ip = 0x0A000050U; /* 10.0.0.80, on the /24 */
+    uint32_t len;
+    int i;
+
+    (void)arp_regr_setup_listener(&s, &ts);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+
+    /* Precondition: neighbor table and pending-ARP table are empty —
+     * no prior ARP exchange of any kind. */
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+    for (i = 0; i < WOLFIP_ARP_PENDING_MAX; i++)
+        ck_assert_uint_eq(s.arp.pending[i].ip, IPADDR_ANY);
+
+    /* Attacker sends one forged SYN: src IP = victim IP, src MAC =
+     * attacker MAC, dst = our listener. Valid checksums. */
+    len = arp_regr_build_syn_frame(frame, ll->mac, arp_regr_att_mac,
+                                   victim_ip, 0x0A000001U, 1234);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    /* The SYN was accepted (no handshake completion required) ... */
+    ck_assert_int_eq(ts->sock.tcp.state, TCP_SYN_RCVD);
+
+    /* ... but the unauthenticated source did not learn anything. */
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+}
+END_TEST
+
+/* =========================================================================
+ * Regression (F-6036): a forged SYN from an off-subnet source must not
+ * poison the GATEWAY entry (the old code stored the route's nexthop,
+ * not the source). (PoC 1b, inverted.)
+ * ========================================================================= */
+START_TEST(test_regression_syn_source_does_not_poison_gateway)
+{
+    struct wolfIP s;
+    struct tsocket *ts;
+    uint8_t frame[ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN];
+    struct wolfIP_ll_dev *ll;
+    ip4 gw_ip = 0x0A00000AU;      /* 10.0.0.10, default gateway */
+    ip4 remote_ip = 0xC0A80909U;  /* 192.168.9.9, off-subnet */
+    uint32_t len;
+
+    (void)arp_regr_setup_listener(&s, &ts);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+    ck_assert_int_eq(wolfIP_route_add(&s, TEST_PRIMARY_IF, 0, 0, gw_ip), 0);
+
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, gw_ip), -1);
+
+    /* One forged SYN from an off-subnet source with the attacker's MAC. */
+    len = arp_regr_build_syn_frame(frame, ll->mac, arp_regr_att_mac,
+                                   remote_ip, 0x0A000001U, 1234);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    ck_assert_int_eq(ts->sock.tcp.state, TCP_SYN_RCVD);
+
+    /* The gateway entry stays absent: routed traffic must ARP for it. */
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, gw_ip), -1);
+}
+END_TEST
+
+/* =========================================================================
+ * Regression (F-6035): downstream effect — after a forged SYN, TX
+ * resolution of the claimed IP finds no entry. (PoC 1c, inverted.)
+ * ========================================================================= */
+START_TEST(test_regression_syn_source_not_resolved_for_tx)
+{
+    struct wolfIP s;
+    struct tsocket *ts;
+    uint8_t frame[ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN];
+    struct wolfIP_ll_dev *ll;
+    ip4 victim_ip = 0x0A000050U;
+    uint8_t mac[6];
+    uint32_t len;
+
+    (void)arp_regr_setup_listener(&s, &ts);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    len = arp_regr_build_syn_frame(frame, ll->mac, arp_regr_att_mac,
+                                   victim_ip, 0x0A000001U, 1234);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    /* No entry: unicast sends to 10.0.0.80 must ARP, not follow the
+     * attacker's MAC. */
+    memset(mac, 0, sizeof(mac));
+    ck_assert_int_eq(wolfIP_arp_lookup_ex(&s, TEST_PRIMARY_IF, victim_ip, mac), -1);
+}
+END_TEST
+
+/* =========================================================================
+ * Regression (F-6035): the only way the owner's MAC gets in is the normal
+ * ARP exchange — a forged SYN and an unsolicited owner reply both install
+ * nothing; the solicited exchange that follows installs the owner's MAC.
+ * (PoC 1d, restructured for the fixed policy.)
+ * ========================================================================= */
+START_TEST(test_regression_syn_learned_only_via_arp_exchange)
+{
+    struct wolfIP s;
+    struct tsocket *ts;
+    uint8_t frame[ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN];
+    struct arp_packet arp;
+    struct wolfIP_ll_dev *ll;
+    ip4 victim_ip = 0x0A000050U;
+    uint32_t len;
+    int idx;
+
+    (void)arp_regr_setup_listener(&s, &ts);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    s.last_tick = 1000;
+
+    /* Forged SYN: nothing installed. */
+    len = arp_regr_build_syn_frame(frame, ll->mac, arp_regr_att_mac,
+                                   victim_ip, 0x0A000001U, 1234);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+
+    /* True owner's unsolicited reply: still nothing installed. */
+    memset(&arp, 0, sizeof(arp));
+    memcpy(arp.eth.dst, ll->mac, 6);
+    memcpy(arp.eth.src, arp_regr_own_mac, 6);
+    arp.eth.type = ee16(ETH_TYPE_ARP);
+    arp.htype  = ee16(1);
+    arp.ptype  = ee16(0x0800);
+    arp.hlen   = 6;
+    arp.plen   = 4;
+    arp.opcode = ee16(ARP_REPLY);
+    memcpy(arp.sma, arp_regr_own_mac, 6);
+    arp.sip = ee32(victim_ip);
+    arp.tip = ee32(0); /* gratuitous form */
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+
+    /* The solicited exchange installs the owner's MAC. */
+    arp_pending_record(&s, TEST_PRIMARY_IF, victim_ip);
+    memset(&arp, 0, sizeof(arp));
+    memcpy(arp.eth.dst, ll->mac, 6);
+    memcpy(arp.eth.src, arp_regr_own_mac, 6);
+    arp.eth.type = ee16(ETH_TYPE_ARP);
+    arp.htype  = ee16(1);
+    arp.ptype  = ee16(0x0800);
+    arp.hlen   = 6;
+    arp.plen   = 4;
+    arp.opcode = ee16(ARP_REPLY);
+    memcpy(arp.sma, arp_regr_own_mac, 6);
+    arp.sip = ee32(victim_ip);
+    arp.tip = ee32(0x0A000001U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
+    idx = arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip);
+    ck_assert_int_gt(idx, -1);
+    ck_assert_mem_eq(s.arp.neighbors[idx].mac, arp_regr_own_mac, 6);
+}
+END_TEST
+
+/* =========================================================================
  * Control (F-9805): an EXISTING entry is not overwritten by an unsolicited
  * reply — the behavior the pending-only gate preserves. (PoC 2e, kept.)
  * ========================================================================= */

--- a/src/test/unit/unit_tests_arp_regression.c
+++ b/src/test/unit/unit_tests_arp_regression.c
@@ -495,3 +495,53 @@ START_TEST(test_regression_unsolicited_reply_overwrite_still_blocked)
     ck_assert_mem_eq(s.arp.neighbors[idx].mac, arp_regr_own_mac, 6);
 }
 END_TEST
+
+/* ---- arp_request: first request is never rate-limited ---- */
+
+START_TEST(test_arp_request_first_not_rate_limited)
+{
+    struct wolfIP s;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+
+    /* Fresh stack at tick 0 (last_arp == 0): the very first request must go
+     * out immediately. Holding it back for the whole 1000-tick window would
+     * delay the first address resolution of a tick domain that just started
+     * (e.g. an RTOS tick handed over from a bare-metal loop). */
+    last_frame_sent_size = 0;
+    arp_request(&s, TEST_PRIMARY_IF, 0x0A000002U);
+    ck_assert_uint_eq(last_frame_sent_size, sizeof(struct arp_packet));
+    ck_assert_uint_eq(s.arp.last_arp[TEST_PRIMARY_IF], 1U);
+
+    /* A second request in the same tick is still suppressed. */
+    last_frame_sent_size = 0;
+    arp_request(&s, TEST_PRIMARY_IF, 0x0A000003U);
+    ck_assert_uint_eq(last_frame_sent_size, 0U);
+}
+END_TEST
+
+START_TEST(test_arp_tick_restart_resets_rate_limit)
+{
+    struct wolfIP s;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+
+    /* Old tick domain: a request went out at tick 5000. */
+    s.last_tick = 5000;
+    s.arp.last_arp[TEST_PRIMARY_IF] = 5000;
+
+    /* The app switches tick sources (e.g. vTaskStartScheduler): the new
+     * domain starts at 0. The stale last_arp must not hold the first
+     * request in the new domain for the whole stale offset. */
+    wolfIP_poll(&s, 0);
+    ck_assert_uint_eq(s.arp.last_arp[TEST_PRIMARY_IF], 0U);
+
+    last_frame_sent_size = 0;
+    arp_request(&s, TEST_PRIMARY_IF, 0x0A000002U);
+    ck_assert_uint_eq(last_frame_sent_size, sizeof(struct arp_packet));
+}
+END_TEST

--- a/src/test/unit/unit_tests_arp_regression.c
+++ b/src/test/unit/unit_tests_arp_regression.c
@@ -21,8 +21,8 @@
 /* =========================================================================
  * ARP neighbor-table regression fixtures
  *
- * Derived from the wire-level PoCs of security-scan candidate
- * candidate-3d6f7442d4b3ac81 (F-9805: unsolicited ARP reply pre-poison),
+ * Derived from the wire-level PoCs of the security scan
+ * (candidate-3d6f7442d4b3ac81, F-9805: unsolicited ARP reply pre-poison),
  * inverted to assert the fixed behavior: a neighbor entry is installed or
  * updated only in answer to a request the stack itself sent (a pending
  * match in arp_recv). Unsolicited frames never touch the table.

--- a/src/test/unit/unit_tests_arp_regression.c
+++ b/src/test/unit/unit_tests_arp_regression.c
@@ -1,0 +1,259 @@
+/* unit_tests_arp_regression.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfIP TCP/IP stack.
+ *
+ * wolfIP is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfIP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+/* =========================================================================
+ * ARP neighbor-table regression fixtures
+ *
+ * Derived from the wire-level PoCs of security-scan candidate
+ * candidate-3d6f7442d4b3ac81 (F-9805: unsolicited ARP reply pre-poison),
+ * inverted to assert the fixed behavior: a neighbor entry is installed or
+ * updated only in answer to a request the stack itself sent (a pending
+ * match in arp_recv). Unsolicited frames never touch the table.
+ * ========================================================================= */
+
+/* Attacker-chosen L2 address (unicast, group bit 0). */
+static const uint8_t arp_regr_att_mac[6] = {0x66, 0x55, 0x44, 0x33, 0x22, 0x11};
+/* "Real owner" L2 address for the victim IP. */
+static const uint8_t arp_regr_own_mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x50};
+
+/* Find neighbor table index for (if_idx, ip); -1 if absent. */
+static int arp_regr_neighbor_find(struct wolfIP *s, unsigned int if_idx, ip4 ip)
+{
+    int i;
+    for (i = 0; i < MAX_NEIGHBORS; i++) {
+        if (s->arp.neighbors[i].ip == ip &&
+                s->arp.neighbors[i].if_idx == (uint8_t)if_idx)
+            return i;
+    }
+    return -1;
+}
+
+static int arp_regr_pending_empty(struct wolfIP *s)
+{
+    int i;
+    for (i = 0; i < WOLFIP_ARP_PENDING_MAX; i++)
+        if (s->arp.pending[i].ip != IPADDR_ANY)
+            return 0;
+    return 1;
+}
+
+/* Standard single-interface setup, 10.0.0.1/24 on the primary link. */
+static void arp_regr_setup(struct wolfIP *s)
+{
+    wolfIP_init(s);
+    mock_link_init(s);
+    wolfIP_ipconfig_set(s, 0x0A000001U, 0xFFFFFF00U, 0);
+    wolfIP_filter_set_callback(NULL, NULL);
+    wolfIP_filter_set_mask(0);
+    wolfIP_filter_set_tcp_mask(0);
+}
+
+/* Build a complete wire frame: Ethernet + ARP REPLY, with attacker-chosen
+ * sender IP/MAC and a chosen target IP. Returns frame length. */
+static uint32_t arp_regr_build_reply_frame(uint8_t *frame, const uint8_t *dst_mac,
+        const uint8_t *src_mac, ip4 sender_ip, const uint8_t *sender_mac,
+        ip4 target_ip)
+{
+    struct arp_packet *arp = (struct arp_packet *)frame;
+
+    memset(frame, 0, sizeof(struct arp_packet));
+    memcpy(arp->eth.dst, dst_mac, 6);
+    memcpy(arp->eth.src, src_mac, 6);
+    arp->eth.type = ee16(ETH_TYPE_ARP);
+    arp->htype  = ee16(1);
+    arp->ptype  = ee16(0x0800);
+    arp->hlen   = 6;
+    arp->plen   = 4;
+    arp->opcode = ee16(ARP_REPLY);
+    memcpy(arp->sma, sender_mac, 6);
+    arp->sip = ee32(sender_ip);
+    memcpy(arp->tma, dst_mac, 6);
+    arp->tip = ee32(target_ip);
+    return sizeof(struct arp_packet);
+}
+
+/* =========================================================================
+ * Regression (F-9805): unsolicited ARP reply with no prior request and no
+ * existing entry must NOT install a neighbor entry. (PoC 2a, inverted.)
+ * ========================================================================= */
+START_TEST(test_regression_unsolicited_reply_first_install_dropped)
+{
+    struct wolfIP s;
+    uint8_t frame[sizeof(struct arp_packet)];
+    struct wolfIP_ll_dev *ll;
+    ip4 victim_ip = 0xC0A84D09U; /* 192.168.77.9 — arbitrary unicast */
+    uint32_t len;
+
+    arp_regr_setup(&s);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+
+    /* Precondition: empty neighbor table AND no outstanding ARP request —
+     * the stack never asked for this IP. */
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+    ck_assert_int_eq(arp_regr_pending_empty(&s), 1);
+
+    /* Attacker broadcasts an unsolicited ARP REPLY claiming victim_ip. */
+    len = arp_regr_build_reply_frame(frame, ll->mac, arp_regr_att_mac,
+                                     victim_ip, arp_regr_att_mac, 0x0A000001U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    /* FIXED BEHAVIOR: no install without a request we sent. */
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+}
+END_TEST
+
+/* =========================================================================
+ * Regression (F-9805): gratuitous-form reply (tip = 0) is dropped too —
+ * no pending request, no install. (PoC 2b, inverted.)
+ * ========================================================================= */
+START_TEST(test_regression_gratuitous_reply_zero_tip_dropped)
+{
+    struct wolfIP s;
+    uint8_t frame[sizeof(struct arp_packet)];
+    struct wolfIP_ll_dev *ll;
+    ip4 victim_ip = 0xC0A84D0AU; /* 192.168.77.10 */
+    uint32_t len;
+
+    arp_regr_setup(&s);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+
+    len = arp_regr_build_reply_frame(frame, ll->mac, arp_regr_att_mac,
+                                     victim_ip, arp_regr_att_mac, 0x00000000U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+}
+END_TEST
+
+/* =========================================================================
+ * Regression (F-9805): unsolicited reply must not pre-poison the gateway
+ * TX path — resolution of the gateway IP finds no entry. (PoC 2c, inverted.)
+ * ========================================================================= */
+START_TEST(test_regression_unsolicited_reply_gateway_not_poisoned)
+{
+    struct wolfIP s;
+    uint8_t frame[sizeof(struct arp_packet)];
+    struct wolfIP_ll_dev *ll;
+    ip4 gw_ip = 0x0A00000AU; /* 10.0.0.10 — default gateway on the /24 */
+    uint8_t mac[6];
+    uint32_t len;
+
+    arp_regr_setup(&s);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, gw_ip), -1);
+    ck_assert_int_eq(arp_regr_pending_empty(&s), 1);
+
+    len = arp_regr_build_reply_frame(frame, ll->mac, arp_regr_att_mac,
+                                     gw_ip, arp_regr_att_mac, 0x0A000001U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    /* No entry: routed sends must ARP for the gateway, not follow the
+     * attacker's MAC. */
+    memset(mac, 0, sizeof(mac));
+    ck_assert_int_eq(wolfIP_arp_lookup_ex(&s, TEST_PRIMARY_IF, gw_ip, mac), -1);
+}
+END_TEST
+
+/* =========================================================================
+ * Regression (F-9805): the only correction path for a wrong entry is a
+ * reply to a request we ourselves sent — an unsolicited owner reply
+ * installs nothing, and the solicited exchange that follows installs the
+ * owner's MAC. (PoC 2d, restructured for the fixed policy.)
+ * ========================================================================= */
+START_TEST(test_regression_owner_correction_requires_our_request)
+{
+    struct wolfIP s;
+    uint8_t frame[sizeof(struct arp_packet)];
+    struct wolfIP_ll_dev *ll;
+    ip4 victim_ip = 0xC0A84D09U; /* 192.168.77.9 */
+    uint32_t len;
+    int idx;
+
+    arp_regr_setup(&s);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+
+    /* Attacker's unsolicited reply: nothing installed. */
+    len = arp_regr_build_reply_frame(frame, ll->mac, arp_regr_att_mac,
+                                     victim_ip, arp_regr_att_mac, 0x0A000001U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+
+    /* True owner's unsolicited reply: still nothing installed. */
+    len = arp_regr_build_reply_frame(frame, ll->mac, arp_regr_own_mac,
+                                     victim_ip, arp_regr_own_mac, 0x0A000001U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+    ck_assert_int_eq(arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip), -1);
+
+    /* We request the IP (pending recorded, bypassing the rate limit) and
+     * the owner answers: the solicited reply installs the owner's MAC. */
+    s.last_tick = 1000;
+    arp_pending_record(&s, TEST_PRIMARY_IF, victim_ip);
+    len = arp_regr_build_reply_frame(frame, ll->mac, arp_regr_own_mac,
+                                     victim_ip, arp_regr_own_mac, 0x0A000001U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    idx = arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip);
+    ck_assert_int_gt(idx, -1);
+    ck_assert_mem_eq(s.arp.neighbors[idx].mac, arp_regr_own_mac, 6);
+}
+END_TEST
+
+/* =========================================================================
+ * Control (F-9805): an EXISTING entry is not overwritten by an unsolicited
+ * reply — the behavior the pending-only gate preserves. (PoC 2e, kept.)
+ * ========================================================================= */
+START_TEST(test_regression_unsolicited_reply_overwrite_still_blocked)
+{
+    struct wolfIP s;
+    uint8_t frame[sizeof(struct arp_packet)];
+    struct wolfIP_ll_dev *ll;
+    ip4 victim_ip = 0xC0A84D0BU; /* 192.168.77.11 */
+    uint32_t len;
+    int idx;
+
+    arp_regr_setup(&s);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+
+    /* Legitimate pre-existing entry (learned via a real reply to a request
+     * we sent). */
+    s.arp.neighbors[0].ip = victim_ip;
+    s.arp.neighbors[0].if_idx = TEST_PRIMARY_IF;
+    memcpy(s.arp.neighbors[0].mac, arp_regr_own_mac, 6);
+    s.arp.neighbors[0].ts = s.last_tick;
+
+    /* Attacker's unsolicited reply for the same IP. */
+    len = arp_regr_build_reply_frame(frame, ll->mac, arp_regr_att_mac,
+                                     victim_ip, arp_regr_att_mac, 0x0A000001U);
+    wolfIP_recv_ex(&s, TEST_PRIMARY_IF, frame, len);
+
+    /* Entry keeps the real MAC. */
+    idx = arp_regr_neighbor_find(&s, TEST_PRIMARY_IF, victim_ip);
+    ck_assert_int_gt(idx, -1);
+    ck_assert_mem_eq(s.arp.neighbors[idx].mac, arp_regr_own_mac, 6);
+}
+END_TEST

--- a/src/test/unit/unit_tests_branches.c
+++ b/src/test/unit/unit_tests_branches.c
@@ -1277,6 +1277,9 @@ START_TEST(test_arp_flush_pending_drops_ttl1)
     ip.dst = ee32(0x0A000050U);
     arp_queue_packet(&s, TEST_PRIMARY_IF, 0x0A000050U, &ip, sizeof(ip));
 
+    /* The store (and thus the flush) now requires a pending request we sent. */
+    arp_pending_record(&s, TEST_PRIMARY_IF, 0x0A000050U);
+
     memset(&reply, 0, sizeof(reply));
     reply.htype = ee16(1);
     reply.ptype = ee16(0x0800);

--- a/src/test/unit/unit_tests_branches.c
+++ b/src/test/unit/unit_tests_branches.c
@@ -1253,10 +1253,13 @@ START_TEST(test_arp_pending_record_replaces_oldest_slot)
     arp_queue_packet(&s, TEST_PRIMARY_IF, 0x0A000010U, &ip, len);
     ck_assert_uint_eq(s.arp_pending[0].dest, 0x0A000010U);
 
-    /* A new destination with no free slot falls back to slot 0. */
+    /* A new destination with no free slot is dropped (F-4057); slot 0
+     * keeps its own frame for 0x0A000010. */
     ip.dst = ee32(0x0A0000A0U);
     arp_queue_packet(&s, TEST_PRIMARY_IF, 0x0A0000A0U, &ip, len);
-    ck_assert_uint_eq(s.arp_pending[0].dest, 0x0A0000A0U);
+    for (i = 0; i < WOLFIP_ARP_PENDING_MAX; i++)
+        ck_assert_uint_ne(s.arp_pending[i].dest, 0x0A0000A0U);
+    ck_assert_uint_eq(s.arp_pending[0].dest, 0x0A000010U);
 }
 END_TEST
 

--- a/src/test/unit/unit_tests_branches.c
+++ b/src/test/unit/unit_tests_branches.c
@@ -2268,21 +2268,28 @@ END_TEST
 START_TEST(test_arp_store_neighbor_full_table)
 {
     struct wolfIP s;
-    uint8_t mac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    uint8_t mac[6] = {0x10, 0x22, 0x33, 0x44, 0x55, 0x66};
     int i;
     wolfIP_init(&s);
     mock_link_init(&s);
+    s.last_tick = 1000;
     for (i = 0; i < MAX_NEIGHBORS; i++) {
         s.arp.neighbors[i].ip = 0x0A000010U + (uint32_t)i;
         s.arp.neighbors[i].if_idx = TEST_PRIMARY_IF;
-        s.arp.neighbors[i].ts = 1;
+        /* Distinct ages; slot 0 is the least recently used. */
+        s.arp.neighbors[i].ts = 1U + (uint64_t)i;
         memset(s.arp.neighbors[i].mac, (uint8_t)i, 6);
     }
-    /* Table is full and no slot matches: store should silently fail. */
+    /* Table is full and no slot matches: the least recently used entry is
+     * evicted and the new neighbor takes its slot (F-6212). */
     arp_store_neighbor(&s, TEST_PRIMARY_IF, 0x0A0000A1U, mac);
-    /* Confirm none of the existing slots was overwritten. */
-    for (i = 0; i < MAX_NEIGHBORS; i++) {
-        ck_assert_uint_ne(s.arp.neighbors[i].ip, 0x0A0000A1U);
+    ck_assert_uint_eq(s.arp.neighbors[0].ip, 0x0A0000A1U);
+    ck_assert_mem_eq(s.arp.neighbors[0].mac, mac, 6);
+    ck_assert_uint_eq(s.arp.neighbors[0].ts, 1000U);
+    /* The rest of the working set is untouched. */
+    for (i = 1; i < MAX_NEIGHBORS; i++) {
+        ck_assert_uint_eq(s.arp.neighbors[i].ip, 0x0A000010U + (uint32_t)i);
+        ck_assert_uint_eq(s.arp.neighbors[i].ts, 1U + (uint64_t)i);
     }
 }
 END_TEST

--- a/src/test/unit/unit_tests_dhcp_edges.c
+++ b/src/test/unit/unit_tests_dhcp_edges.c
@@ -1695,3 +1695,53 @@ START_TEST(test_dhcp_dad_probe_count_len_returning_driver)
     ck_assert_uint_eq(dad_len_send_count, DHCP_DAD_PROBES);
 }
 END_TEST
+
+/* DECLINE wire format (RFC 2131 §4.4): the client never bound the address,
+ * so ciaddr stays 0.0.0.0; the declined address is carried in option 50
+ * (Requested IP), alongside the server ID. */
+START_TEST(test_dhcp_decline_wire_format)
+{
+    struct wolfIP s;
+    struct wolfIP_udp_datagram *udp;
+    struct dhcp_msg *dec;
+    struct dhcp_option *opt;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    ck_assert_int_eq(dhcp_client_init(&s), 0);
+
+    /* The ACK offered client_ip; DAD detected a conflict. */
+    s.dhcp_ip = client_ip;
+    s.dhcp_server_ip = server_ip;
+    s.dhcp_state = DHCP_DAD;
+
+    last_frame_sent_size = 0;
+    ck_assert_int_ge(dhcp_send_decline(&s), 0);
+    (void)wolfIP_poll(&s, s.last_tick);
+
+    /* L2 frame: the udp datagram struct carries its own eth + IP + UDP
+     * headers; the sent DHCP payload is DHCP_HEADER_LEN + the options
+     * actually used, not the whole struct. */
+    ck_assert_uint_gt(last_frame_sent_size,
+                      (uint32_t)sizeof(struct wolfIP_udp_datagram) +
+                      DHCP_HEADER_LEN);
+    udp = (struct wolfIP_udp_datagram *)last_frame_sent;
+    dec = (struct dhcp_msg *)udp->data;
+    ck_assert_uint_eq(dec->op, BOOT_REQUEST);
+    ck_assert_uint_eq(dec->ciaddr, 0U); /* never bound */
+
+    opt = (struct dhcp_option *)dec->options;
+    ck_assert_uint_eq(opt->code, DHCP_OPTION_MSG_TYPE);
+    ck_assert_uint_eq(opt->data[0], DHCP_DECLINE);
+    opt = (struct dhcp_option *)((uint8_t *)opt + 3);
+    ck_assert_uint_eq(opt->code, DHCP_OPTION_SERVER_ID);
+    ck_assert_uint_eq(DHCP_OPT_data_to_u32(opt), server_ip);
+    opt = (struct dhcp_option *)((uint8_t *)opt + 6);
+    ck_assert_uint_eq(opt->code, DHCP_OPTION_OFFER_IP); /* option 50 */
+    ck_assert_uint_eq(opt->len, 4);
+    ck_assert_uint_eq(DHCP_OPT_data_to_u32(opt), client_ip);
+}
+END_TEST

--- a/src/test/unit/unit_tests_dhcp_edges.c
+++ b/src/test/unit/unit_tests_dhcp_edges.c
@@ -1555,6 +1555,49 @@ START_TEST(test_dhcp_dad_own_mac_reply_ignored)
 }
 END_TEST
 
+/* The ACK must leave exactly one DHCP timer in the heap (the DAD timer),
+ * and DAD completion must leave exactly one (the renew timer): the lease
+ * timer is swapped out, not stacked, or handle_timers would fire the
+ * renewal twice. */
+START_TEST(test_dhcp_dad_single_dhcp_timer_in_heap)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    uint32_t i, count;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xDA05U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.last_tick = 1000U;
+    wolfIP_primary_ipconf(&s)->ip = client_ip;
+
+    build_full_ack(&s, &msg, server_ip, client_ip, 0xFFFFFF00U,
+                   server_ip, 0x08080808U, 120U);
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
+
+    count = 0;
+    for (i = 0; i < s.timers.size; i++)
+        if (s.timers.timers[i].expires != 0 &&
+            s.timers.timers[i].cb == dhcp_timer_cb)
+            count++;
+    ck_assert_uint_eq(count, 1U);
+
+    dhcp_test_complete_dad(&s);
+
+    count = 0;
+    for (i = 0; i < s.timers.size; i++)
+        if (s.timers.timers[i].expires != 0 &&
+            s.timers.timers[i].cb == dhcp_timer_cb)
+            count++;
+    ck_assert_uint_eq(count, 1U);
+    ck_assert_int_ne(s.dhcp_timer, NO_TIMER);
+    ck_assert_uint_eq(find_timer_expiry(&s, s.dhcp_timer), s.dhcp_renew_at);
+}
+END_TEST
+
 /* During DAD, a reply for a different IP is not a conflict: the hook only
  * acts on replies claiming the address being probed. */
 START_TEST(test_dhcp_dad_reply_for_other_ip_ignored)

--- a/src/test/unit/unit_tests_dhcp_edges.c
+++ b/src/test/unit/unit_tests_dhcp_edges.c
@@ -899,6 +899,7 @@ START_TEST(test_dhcp_parse_ack_with_renewal_and_rebind_times)
     uint32_t client_ip = 0x0A000064U;
 
     wolfIP_init(&s);
+    mock_link_init(&s);
     s.dhcp_xid = 0xEE55U;
     s.last_tick = 0U;
     primary = wolfIP_primary_ipconf(&s);
@@ -916,7 +917,8 @@ START_TEST(test_dhcp_parse_ack_with_renewal_and_rebind_times)
     append_end(&p);
 
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    /* ACK -> DAD (RFC 4331); complete the probes to reach BOUND. */
+    dhcp_test_complete_dad(&s);
     ck_assert_uint_eq(s.dhcp_renew_at, 1800000U);
     ck_assert_uint_eq(s.dhcp_rebind_at, 3150000U);
     ck_assert_uint_eq(s.dhcp_lease_expires, 3600000U);
@@ -967,6 +969,7 @@ START_TEST(test_dhcp_parse_ack_inner_pad_bytes_skipped)
     uint32_t client_ip = 0x0A000064U;
 
     wolfIP_init(&s);
+    mock_link_init(&s);
     s.dhcp_xid = 0x1122U;
     primary = wolfIP_primary_ipconf(&s);
     ck_assert_ptr_nonnull(primary);
@@ -983,7 +986,8 @@ START_TEST(test_dhcp_parse_ack_inner_pad_bytes_skipped)
     append_end(&p);
 
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    /* ACK -> DAD (RFC 4331); complete the probes to reach BOUND. */
+    dhcp_test_complete_dad(&s);
 }
 END_TEST
 
@@ -1200,6 +1204,7 @@ START_TEST(test_dhcp_parse_ack_without_lease_time_rejected)
     uint8_t *p;
 
     wolfIP_init(&s);
+    mock_link_init(&s);
     s.dhcp_xid = 0x5482U;
     s.dhcp_server_ip = 0x0A000001U;
     s.dhcp_state = DHCP_REQUEST_SENT;
@@ -1228,13 +1233,13 @@ START_TEST(test_dhcp_parse_ack_without_lease_time_rejected)
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), -1);
     ck_assert_int_ne(s.dhcp_state, DHCP_BOUND);
 
-    /* (3) The same ACK with a valid nonzero lease time binds and schedules a
-     * lease timer. */
+    /* (3) The same ACK with a valid nonzero lease time goes through DAD
+     * (RFC 4331) to BOUND and schedules a lease timer. */
     build_full_ack(&s, &msg, 0x0A000001U, 0x0A000064U, 0xFFFFFF00U,
                    0x0A000001U, 0x08080808U, 120U);
     s.dhcp_timer = NO_TIMER;
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    dhcp_test_complete_dad(&s);
     ck_assert_int_ne(s.dhcp_timer, NO_TIMER);
 }
 END_TEST
@@ -1269,7 +1274,8 @@ START_TEST(test_dhcp_lease_expiry_relearns_dns_server)
     build_full_ack(&s, &msg, first_srv, client_ip, mask, first_srv,
                    first_dns, 120U);
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    /* ACK -> DAD (RFC 4331); complete the probes to reach BOUND. */
+    dhcp_test_complete_dad(&s);
     ck_assert_uint_eq(s.dns_server, first_dns);
     ck_assert_uint_ne(s.dhcp_lease_expires, 0U);
 
@@ -1289,7 +1295,8 @@ START_TEST(test_dhcp_lease_expiry_relearns_dns_server)
     build_full_ack(&s, &msg, second_srv, client_ip, mask, second_srv,
                    second_dns, 120U);
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    /* ACK -> DAD (RFC 4331); complete the probes to reach BOUND. */
+    dhcp_test_complete_dad(&s);
     ck_assert_uint_eq(s.dhcp_server_ip, second_srv);
     ck_assert_uint_eq(s.dns_server, second_dns);
 }
@@ -1368,6 +1375,8 @@ START_TEST(test_dhcp_lease_expiry_keeps_pinned_dns_server)
                    offered_dns, 120U);
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
     ck_assert_uint_eq(s.dns_server, pinned_dns);
+    /* ACK -> DAD (RFC 4331); complete the probes to reach BOUND. */
+    dhcp_test_complete_dad(&s);
 
     s.last_tick = s.dhcp_lease_expires;
     dhcp_timer_cb(&s);
@@ -1391,5 +1400,202 @@ START_TEST(test_dhcp_public_apis_null_stack_safe)
     ck_assert_int_eq(dhcp_bound(NULL), 0);
     ck_assert_int_eq(dhcp_client_is_running(NULL), 0);
     ck_assert_int_eq(dhcp_client_init(NULL), -WOLFIP_EINVAL);
+}
+END_TEST
+
+/* =========================================================================
+ * RFC 4331 DAD after DHCPACK
+ * ========================================================================= */
+
+/* A DHCPACK does not bind immediately: the client enters DAD and sends the
+ * first probe right away — an ARP request with sip = 0.0.0.0 and tip = the
+ * offered address. The lease timers are already armed for when the probes
+ * complete. */
+START_TEST(test_dhcp_dad_probe_wire_format)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct wolfIP_ll_dev *ll;
+    struct arp_packet *arp;
+    struct ipconf *primary;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xDA01U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.last_tick = 1000U;
+    primary = wolfIP_primary_ipconf(&s);
+    ck_assert_ptr_nonnull(primary);
+    primary->ip = client_ip;
+
+    build_full_ack(&s, &msg, server_ip, client_ip, 0xFFFFFF00U,
+                   server_ip, 0x08080808U, 120U);
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+    last_frame_sent_size = 0;
+
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
+
+    /* In DAD, first probe sent, lease timers armed. */
+    ck_assert_int_eq(s.dhcp_state, DHCP_DAD);
+    ck_assert_uint_eq(s.dhcp_dad_probes, 1U);
+    ck_assert_uint_ne(s.dhcp_renew_at, 0U);
+    ck_assert_uint_ne(s.dhcp_lease_expires, 0U);
+
+    /* Probe wire format: REQUEST, sip = 0.0.0.0, tip = offered IP,
+     * our MAC as sender. */
+    ck_assert_uint_eq(last_frame_sent_size, sizeof(struct arp_packet));
+    arp = (struct arp_packet *)last_frame_sent;
+    ck_assert_int_eq(arp->opcode, ee16(ARP_REQUEST));
+    ck_assert_int_eq(arp->sip, ee32(IPADDR_ANY));
+    ck_assert_int_eq(arp->tip, ee32(client_ip));
+    ck_assert_mem_eq(arp->sma, ll->mac, 6);
+    ck_assert_mem_eq(arp->tma, "\x00\x00\x00\x00\x00\x00", 6);
+}
+END_TEST
+
+/* A DAD probe answered by a host other than us is a conflict: the address
+ * is released, a DECLINE is sent (when a DHCP socket exists), and the
+ * client restarts at DISCOVER. */
+START_TEST(test_dhcp_dad_conflict_releases_and_rediscover)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct arp_packet reply;
+    struct wolfIP_ll_dev *ll;
+    struct ipconf *primary;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+    uint8_t other_mac[6] = {0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0x02};
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xDA02U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.last_tick = 1000U;
+    primary = wolfIP_primary_ipconf(&s);
+    ck_assert_ptr_nonnull(primary);
+    primary->ip = client_ip;
+
+    build_full_ack(&s, &msg, server_ip, client_ip, 0xFFFFFF00U,
+                   server_ip, 0x08080808U, 120U);
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
+    ck_assert_int_eq(s.dhcp_state, DHCP_DAD);
+
+    /* A host that owns the address answers our probe. */
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+    memset(&reply, 0, sizeof(reply));
+    memcpy(reply.eth.dst, ll->mac, 6);
+    memcpy(reply.eth.src, other_mac, 6);
+    reply.eth.type = ee16(ETH_TYPE_ARP);
+    reply.htype = ee16(1);
+    reply.ptype = ee16(0x0800);
+    reply.hlen = 6;
+    reply.plen = 4;
+    reply.opcode = ee16(ARP_REPLY);
+    memcpy(reply.sma, other_mac, 6);
+    reply.sip = ee32(client_ip);
+    reply.tip = ee32(0x0A000001U);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &reply, sizeof(reply));
+
+    /* Address released, DAD aborted, back to discovery. */
+    ck_assert_uint_eq(s.dhcp_dad_probes, 0U);
+    ck_assert_uint_eq(primary->ip, 0U);
+    ck_assert_int_eq(s.dhcp_state, DHCP_DISCOVER_SENT);
+}
+END_TEST
+
+/* A reply with our own MAC is our own probe looping back: ignored, DAD
+ * continues. */
+START_TEST(test_dhcp_dad_own_mac_reply_ignored)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct arp_packet reply;
+    struct wolfIP_ll_dev *ll;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xDA03U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.last_tick = 1000U;
+    wolfIP_primary_ipconf(&s)->ip = client_ip;
+
+    build_full_ack(&s, &msg, server_ip, client_ip, 0xFFFFFF00U,
+                   server_ip, 0x08080808U, 120U);
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
+    ck_assert_int_eq(s.dhcp_state, DHCP_DAD);
+
+    /* Our own probe comes back (e.g. switched loopback): same MAC. */
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+    memset(&reply, 0, sizeof(reply));
+    memcpy(reply.eth.dst, ll->mac, 6);
+    memcpy(reply.eth.src, ll->mac, 6);
+    reply.eth.type = ee16(ETH_TYPE_ARP);
+    reply.htype = ee16(1);
+    reply.ptype = ee16(0x0800);
+    reply.hlen = 6;
+    reply.plen = 4;
+    reply.opcode = ee16(ARP_REPLY);
+    memcpy(reply.sma, ll->mac, 6);
+    reply.sip = ee32(client_ip);
+    reply.tip = ee32(0x0A000001U);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &reply, sizeof(reply));
+
+    ck_assert_int_eq(s.dhcp_state, DHCP_DAD);
+    ck_assert_uint_eq(s.dhcp_dad_probes, 1U);
+}
+END_TEST
+
+/* During DAD, a reply for a different IP is not a conflict: the hook only
+ * acts on replies claiming the address being probed. */
+START_TEST(test_dhcp_dad_reply_for_other_ip_ignored)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct arp_packet reply;
+    struct wolfIP_ll_dev *ll;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xDA04U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.last_tick = 1000U;
+    wolfIP_primary_ipconf(&s)->ip = client_ip;
+
+    build_full_ack(&s, &msg, server_ip, client_ip, 0xFFFFFF00U,
+                   server_ip, 0x08080808U, 120U);
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
+    ck_assert_int_eq(s.dhcp_state, DHCP_DAD);
+
+    /* An ordinary reply for someone else's address: not our problem. */
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+    memset(&reply, 0, sizeof(reply));
+    memcpy(reply.eth.dst, ll->mac, 6);
+    reply.eth.type = ee16(ETH_TYPE_ARP);
+    reply.htype = ee16(1);
+    reply.ptype = ee16(0x0800);
+    reply.hlen = 6;
+    reply.plen = 4;
+    reply.opcode = ee16(ARP_REPLY);
+    reply.sma[0] = 0x02; reply.sma[5] = 0x77;
+    reply.sip = ee32(0x0A000099U);
+    reply.tip = ee32(client_ip);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &reply, sizeof(reply));
+
+    ck_assert_int_eq(s.dhcp_state, DHCP_DAD);
+    ck_assert_uint_eq(s.dhcp_dad_probes, 1U);
 }
 END_TEST

--- a/src/test/unit/unit_tests_dhcp_edges.c
+++ b/src/test/unit/unit_tests_dhcp_edges.c
@@ -1642,3 +1642,56 @@ START_TEST(test_dhcp_dad_reply_for_other_ip_ignored)
     ck_assert_uint_eq(s.dhcp_dad_probes, 1U);
 }
 END_TEST
+
+/* Real ll drivers (stm32, lpc, fman, gem, tap) return the frame length on
+ * send success, not 0. The DAD probe counter must treat any non-negative
+ * return as "sent"; otherwise the first probe is miscounted, a fourth probe
+ * goes out, BOUND is delayed a full extra interval, and the m33mu CI app
+ * hits its DHCP safety timeout and falls back to the static IP. */
+static uint32_t dad_len_send_count = 0;
+
+static int dad_len_send(struct wolfIP_ll_dev *dev, void *frame, uint32_t len)
+{
+    (void)dev;
+    (void)frame;
+    if (len == sizeof(struct arp_packet))
+        dad_len_send_count++;
+    return (int)len;
+}
+
+START_TEST(test_dhcp_dad_probe_count_len_returning_driver)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct wolfIP_ll_dev *ll;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xDA06U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.last_tick = 1000U;
+    wolfIP_primary_ipconf(&s)->ip = client_ip;
+
+    /* Simulate the real drivers: success returns len, not 0. */
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    ck_assert_ptr_nonnull(ll);
+    dad_len_send_count = 0;
+    ll->send = dad_len_send;
+
+    build_full_ack(&s, &msg, server_ip, client_ip, 0xFFFFFF00U,
+                   server_ip, 0x08080808U, 120U);
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
+
+    ck_assert_int_eq(s.dhcp_state, DHCP_DAD);
+    /* Probe 1 was counted despite the len return. */
+    ck_assert_uint_eq(s.dhcp_dad_probes, 1U);
+    ck_assert_uint_eq(dad_len_send_count, 1U);
+
+    dhcp_test_complete_dad(&s);
+
+    /* RFC 4331: exactly 3 probes, then BOUND. */
+    ck_assert_uint_eq(dad_len_send_count, DHCP_DAD_PROBES);
+}
+END_TEST

--- a/src/test/unit/unit_tests_dns_dhcp.c
+++ b/src/test/unit/unit_tests_dns_dhcp.c
@@ -129,6 +129,7 @@ START_TEST(test_dhcp_parse_offer_and_ack)
     uint32_t lease_s = 120U;
 
     wolfIP_init(&s);
+    mock_link_init(&s);
     primary = wolfIP_primary_ipconf(&s);
     ck_assert_ptr_nonnull(primary);
 
@@ -219,7 +220,8 @@ START_TEST(test_dhcp_parse_offer_and_ack)
     opt->len = 0;
 
     ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    /* ACK -> DAD (RFC 4331); complete the probes to reach BOUND. */
+    dhcp_test_complete_dad(&s);
     ck_assert_uint_eq(primary->ip, offer_ip);
     ck_assert_uint_eq(primary->mask, mask);
     ck_assert_uint_eq(primary->gw, router_ip);
@@ -5088,7 +5090,8 @@ START_TEST(test_dhcp_poll_offer_and_ack)
     enqueue_udp_rx(ts, &msg, sizeof(msg), DHCP_SERVER_PORT);
     ret = dhcp_poll(&s);
     ck_assert_int_eq(ret, 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    /* ACK -> DAD (RFC 4331); complete the probes to reach BOUND. */
+    dhcp_test_complete_dad(&s);
 }
 END_TEST
 
@@ -5125,9 +5128,10 @@ START_TEST(test_dhcp_poll_renewing_ack_binds_client)
     enqueue_udp_rx(ts, &msg, sizeof(msg), DHCP_SERVER_PORT);
     ret = dhcp_poll(&s);
 
-    /* The poll dispatcher should route renewing traffic through ACK parsing to BOUND. */
+    /* The poll dispatcher should route renewing traffic through ACK parsing
+     * to DAD (RFC 4331); complete the probes to reach BOUND. */
     ck_assert_int_eq(ret, 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    dhcp_test_complete_dad(&s);
     ck_assert_uint_eq(primary->ip, client_ip);
     ck_assert_uint_eq(primary->mask, mask);
     ck_assert_uint_eq(primary->gw, router_ip);
@@ -5168,9 +5172,10 @@ START_TEST(test_dhcp_poll_rebinding_ack_binds_client)
     enqueue_udp_rx(ts, &msg, sizeof(msg), DHCP_SERVER_PORT);
     ret = dhcp_poll(&s);
 
-    /* Rebinding ACKs should also drive the client back to BOUND with refreshed config. */
+    /* Rebinding ACKs should also drive the client through DAD (RFC 4331)
+     * back to BOUND with refreshed config. */
     ck_assert_int_eq(ret, 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_BOUND);
+    dhcp_test_complete_dad(&s);
     ck_assert_uint_eq(primary->ip, client_ip);
     ck_assert_uint_eq(primary->mask, mask);
     ck_assert_uint_eq(primary->gw, router_ip);

--- a/src/test/unit/unit_tests_ip_arp_recv.c
+++ b/src/test/unit/unit_tests_ip_arp_recv.c
@@ -1294,6 +1294,145 @@ START_TEST(test_arp_recv_reply_sender_zero_ip_rejected)
 END_TEST
 
 /* =========================================================================
+ * arp_recv: broadcast/multicast sender MAC — dropped (F-10274)
+ * =========================================================================
+ * A frame whose sender MAC has the Ethernet group bit set (broadcast or
+ * multicast) cannot identify a unicast host, so the entry it would create
+ * could only blackhole or misdirect traffic. Drop such frames before any
+ * opcode processing, for both REQUEST and REPLY.
+ */
+START_TEST(test_arp_recv_reply_broadcast_sma_dropped)
+{
+    struct wolfIP s;
+    struct arp_packet arp;
+    struct wolfIP_ll_dev *ll;
+    ip4 sender_ip = 0x0A000020U;
+    static const uint8_t bcast_mac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+
+    memset(&arp, 0, sizeof(arp));
+    memcpy(arp.eth.dst, ll->mac, 6);
+    memcpy(arp.eth.src, bcast_mac, 6);
+    arp.eth.type = ee16(ETH_TYPE_ARP);
+    arp.htype    = ee16(1);
+    arp.ptype    = ee16(0x0800);
+    arp.hlen     = 6;
+    arp.plen     = 4;
+    arp.opcode   = ee16(ARP_REPLY);
+    memcpy(arp.sma, bcast_mac, 6);
+    arp.sip      = ee32(sender_ip);
+    memset(arp.tma, 0, 6);
+    arp.tip      = ee32(0x0A000001U);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
+    /* A group sender MAC must never install a neighbor entry */
+    ck_assert_int_lt(arp_neighbor_index(&s, TEST_PRIMARY_IF, sender_ip), 0);
+}
+END_TEST
+
+START_TEST(test_arp_recv_reply_multicast_sma_dropped)
+{
+    struct wolfIP s;
+    struct arp_packet arp;
+    struct wolfIP_ll_dev *ll;
+    ip4 sender_ip = 0x0A000021U;
+    static const uint8_t mcast_mac[6] = {0x01, 0x00, 0x5E, 0x00, 0x00, 0x02};
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+
+    memset(&arp, 0, sizeof(arp));
+    memcpy(arp.eth.dst, ll->mac, 6);
+    memcpy(arp.eth.src, mcast_mac, 6);
+    arp.eth.type = ee16(ETH_TYPE_ARP);
+    arp.htype    = ee16(1);
+    arp.ptype    = ee16(0x0800);
+    arp.hlen     = 6;
+    arp.plen     = 4;
+    arp.opcode   = ee16(ARP_REPLY);
+    memcpy(arp.sma, mcast_mac, 6);
+    arp.sip      = ee32(sender_ip);
+    memset(arp.tma, 0, 6);
+    arp.tip      = ee32(0x0A000001U);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
+    ck_assert_int_lt(arp_neighbor_index(&s, TEST_PRIMARY_IF, sender_ip), 0);
+}
+END_TEST
+
+START_TEST(test_arp_recv_request_broadcast_sma_dropped)
+{
+    struct wolfIP s;
+    struct arp_packet arp;
+    struct wolfIP_ll_dev *ll;
+    struct ipconf *conf;
+    ip4 sender_ip = 0x0A000022U;
+    static const uint8_t bcast_mac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    s.last_tick = 5000;
+
+    ll   = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    conf = wolfIP_ipconf_at(&s, TEST_PRIMARY_IF);
+    wolfIP_filter_set_callback(NULL, NULL);
+    last_frame_sent_size = 0;
+
+    build_valid_arp_request(&arp, ll, conf->ip, sender_ip);
+    memcpy(arp.sma, bcast_mac, 6);
+    memcpy(arp.eth.src, bcast_mac, 6);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
+    /* No reply may be sent in answer to a group-MAC request, and nothing
+     * may be learned from it */
+    ck_assert_uint_eq(last_frame_sent_size, 0);
+    ck_assert_int_lt(arp_neighbor_index(&s, TEST_PRIMARY_IF, sender_ip), 0);
+}
+END_TEST
+
+START_TEST(test_arp_recv_request_multicast_sma_dropped)
+{
+    struct wolfIP s;
+    struct arp_packet arp;
+    struct wolfIP_ll_dev *ll;
+    struct ipconf *conf;
+    ip4 sender_ip = 0x0A000023U;
+    static const uint8_t mcast_mac[6] = {0x01, 0x00, 0x5E, 0x00, 0x00, 0x03};
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    s.last_tick = 5000;
+
+    ll   = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    conf = wolfIP_ipconf_at(&s, TEST_PRIMARY_IF);
+    wolfIP_filter_set_callback(NULL, NULL);
+    last_frame_sent_size = 0;
+
+    build_valid_arp_request(&arp, ll, conf->ip, sender_ip);
+    memcpy(arp.sma, mcast_mac, 6);
+    memcpy(arp.eth.src, mcast_mac, 6);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &arp, sizeof(arp));
+
+    ck_assert_uint_eq(last_frame_sent_size, 0);
+    ck_assert_int_lt(arp_neighbor_index(&s, TEST_PRIMARY_IF, sender_ip), 0);
+}
+END_TEST
+
+/* =========================================================================
  * arp_recv: a valid ARP request is answered but does NOT install a neighbor;
  *           only a following REPLY populates the cache
  * =========================================================================

--- a/src/test/unit/unit_tests_proto.c
+++ b/src/test/unit/unit_tests_proto.c
@@ -2739,6 +2739,9 @@ START_TEST(test_arp_reply_handling) {
     arp_reply.sip = ee32(reply_ip);
     memcpy(arp_reply.sma, reply_mac, 6);
 
+    /* Installs only in answer to a request we sent (pending-only gate). */
+    arp_pending_record(&s, TEST_PRIMARY_IF, reply_ip);
+
     /* Call arp_recv with the ARP reply */
     arp_recv(&s, TEST_PRIMARY_IF, &arp_reply, sizeof(arp_reply));
 
@@ -2964,6 +2967,9 @@ START_TEST(test_arp_reply_updates_expired_entry)
     s.arp.neighbors[0].if_idx = TEST_PRIMARY_IF;
     s.arp.neighbors[0].ts = 0;
     memcpy(s.arp.neighbors[0].mac, old_mac, 6);
+
+    /* The update happens only in answer to a request we sent. */
+    arp_pending_record(&s, TEST_PRIMARY_IF, reply_ip);
 
     arp_reply.htype = ee16(1);
     arp_reply.ptype = ee16(0x0800);

--- a/src/test/unit/unit_tests_proto.c
+++ b/src/test/unit/unit_tests_proto.c
@@ -6146,6 +6146,84 @@ START_TEST(test_regression_loopback_ack_retry_pending_requeued_on_poll)
 }
 END_TEST
 
+/* F-10261: a pure ACK that takes the immediate path (TX FIFO saturated)
+ * with an unresolved nexthop: the ARP miss must report -WOLFIP_EAGAIN so
+ * the retry is scheduled instead of being lost; once the solicited reply
+ * arrives, the next tcp_send_ack transmits and clears the flag. */
+START_TEST(test_regression_pure_ack_arp_miss_schedules_retry)
+{
+    struct wolfIP s;
+    struct tsocket *ts;
+    struct wolfIP_ll_dev *ll;
+    struct arp_packet reply;
+    uint8_t payload[256];
+    uint8_t mac[6] = {0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0x01};
+    ip4 remote_ip = 0x0A000020U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    wolfIP_filter_set_callback(NULL, NULL);
+    wolfIP_filter_set_mask(0);
+    s.last_tick = 5000;
+
+    ts = &s.tcpsockets[0];
+    memset(ts, 0, sizeof(*ts));
+    ts->proto = WI_IPPROTO_TCP;
+    ts->S = &s;
+    ts->if_idx = TEST_PRIMARY_IF;
+    ts->sock.tcp.state = TCP_ESTABLISHED;
+    ts->sock.tcp.ack = 100;
+    ts->sock.tcp.seq = 1000;
+    ts->src_port = 1234;
+    ts->dst_port = 4321;
+    ts->local_ip = 0x0A000001U;
+    ts->remote_ip = remote_ip;
+    fifo_init(&ts->sock.tcp.txbuf, ts->txmem, TXBUF_SIZE);
+
+    /* Saturate the shared data/control TX FIFO so tcp_send_empty() takes
+     * the immediate pure-ACK path. Large pushes leave a small slack that
+     * an ACK segment would still fit in, so top up with minimal pushes
+     * until the FIFO is truly full. */
+    memset(payload, 0, sizeof(payload));
+    while (fifo_push(&ts->sock.tcp.txbuf, payload, sizeof(payload)) == 0)
+        ;
+    while (fifo_push(&ts->sock.tcp.txbuf, payload, 4) == 0)
+        ;
+
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+    last_frame_sent_size = 0;
+
+    /* ARP miss: no segment can go out, the request is sent instead, and
+     * the pure-ACK retry must be scheduled (previously discarded). */
+    tcp_send_ack(ts);
+    ck_assert_uint_eq(ts->sock.tcp.ack_retry_pending, 1U);
+    ck_assert_uint_gt(last_frame_sent_size, 0U);
+
+    /* The owner answers our request: the solicited reply installs the
+     * entry, and the next tcp_send_ack transmits, clearing the flag. */
+    memset(&reply, 0, sizeof(reply));
+    memcpy(reply.eth.dst, ll->mac, 6);
+    memcpy(reply.eth.src, mac, 6);
+    reply.eth.type = ee16(ETH_TYPE_ARP);
+    reply.htype = ee16(1);
+    reply.ptype = ee16(0x0800);
+    reply.hlen = 6;
+    reply.plen = 4;
+    reply.opcode = ee16(ARP_REPLY);
+    memcpy(reply.sma, mac, 6);
+    reply.sip = ee32(remote_ip);
+    reply.tip = ee32(0x0A000001U);
+    last_frame_sent_size = 0;
+    arp_recv(&s, TEST_PRIMARY_IF, &reply, sizeof(reply));
+    ck_assert_int_gt(arp_neighbor_index(&s, TEST_PRIMARY_IF, remote_ip), -1);
+
+    tcp_send_ack(ts);
+    ck_assert_uint_eq(ts->sock.tcp.ack_retry_pending, 0U);
+    ck_assert_uint_gt(last_frame_sent_size, 0U);
+}
+END_TEST
+
 START_TEST(test_regression_loopback_queue_full_pure_ack_backpressure_retry)
 {
     struct wolfIP s;

--- a/src/test/unit/unit_tests_proto.c
+++ b/src/test/unit/unit_tests_proto.c
@@ -2783,7 +2783,8 @@ START_TEST(test_arp_reply_with_pending_request_updates)
     struct arp_packet arp_reply;
     uint32_t reply_ip = 0xC0A80003; /* 192.168.0.3 */
     uint8_t old_mac[6] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15};
-    uint8_t new_mac[6] = {0x21, 0x22, 0x23, 0x24, 0x25, 0x26};
+    /* Sender MAC must be unicast (group bit 0) or arp_recv drops the frame */
+    uint8_t new_mac[6] = {0x20, 0x22, 0x23, 0x24, 0x25, 0x26};
     struct wolfIP s;
 
     memset(&arp_reply, 0, sizeof(arp_reply));
@@ -2950,7 +2951,8 @@ START_TEST(test_arp_reply_updates_expired_entry)
     struct arp_packet arp_reply;
     uint32_t reply_ip = 0xC0A80003; /* 192.168.0.3 */
     uint8_t old_mac[6] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15};
-    uint8_t new_mac[6] = {0x21, 0x22, 0x23, 0x24, 0x25, 0x26};
+    /* Sender MAC must be unicast (group bit 0) or arp_recv drops the frame */
+    uint8_t new_mac[6] = {0x20, 0x22, 0x23, 0x24, 0x25, 0x26};
     struct wolfIP s;
 
     memset(&arp_reply, 0, sizeof(arp_reply));

--- a/src/test/unit/unit_tests_tcp_ack.c
+++ b/src/test/unit/unit_tests_tcp_ack.c
@@ -1677,7 +1677,7 @@ START_TEST(test_arp_flush_pending_ttl_expired)
     arp_reply.plen = 4;
     arp_reply.opcode = ee16(ARP_REPLY);
     arp_reply.sip = ee32(dest_ip);
-    memcpy(arp_reply.sma, "\x01\x02\x03\x04\x05\x06", 6);
+    memcpy(arp_reply.sma, "\x66\x55\x44\x33\x22\x11", 6); /* unicast sender */
     arp_recv(&s, TEST_SECOND_IF, &arp_reply, sizeof(arp_reply));
     ck_assert_uint_eq(last_frame_sent_size, 0);
     ck_assert_uint_eq(s.arp_pending[0].dest, IPADDR_ANY);
@@ -2314,7 +2314,7 @@ START_TEST(test_arp_recv_request_sends_reply)
     arp_req.plen = 4;
     arp_req.opcode = ee16(ARP_REQUEST);
     arp_req.sip = ee32(0x0A000002U);
-    memcpy(arp_req.sma, "\x01\x02\x03\x04\x05\x06", 6);
+    memcpy(arp_req.sma, "\x66\x55\x44\x33\x22\x11", 6); /* unicast sender */
     arp_req.tip = ee32(0x0A000001U);
 
     arp_recv(&s, TEST_PRIMARY_IF, &arp_req, sizeof(arp_req));

--- a/src/test/unit/unit_tests_tcp_ack.c
+++ b/src/test/unit/unit_tests_tcp_ack.c
@@ -1781,7 +1781,7 @@ START_TEST(test_arp_queue_packet_drops_oversize_len)
 }
 END_TEST
 
-START_TEST(test_arp_queue_packet_slot_fallback_zero)
+START_TEST(test_arp_queue_packet_full_drops_new_dest)
 {
     struct wolfIP s;
     struct wolfIP_ip_packet ip;
@@ -1797,8 +1797,14 @@ START_TEST(test_arp_queue_packet_slot_fallback_zero)
         s.arp_pending[i].len = 1;
     }
 
+    /* Queue full with distinct destinations: a new destination is dropped,
+     * not queued into slot 0 (clobbering it would silently lose the oldest
+     * pending frame for an unrelated destination, F-4057). Upstream
+     * retransmits the dropped frame. */
     arp_queue_packet(&s, TEST_PRIMARY_IF, 0x0A0000C1U, &ip, (uint32_t)(ETH_HEADER_LEN + IP_HEADER_LEN));
-    ck_assert_uint_eq(s.arp_pending[0].dest, 0x0A0000C1U);
+    for (i = 0; i < WOLFIP_ARP_PENDING_MAX; i++)
+        ck_assert_uint_ne(s.arp_pending[i].dest, 0x0A0000C1U);
+    ck_assert_uint_eq(s.arp_pending[0].dest, 0x0A000100U);
 }
 END_TEST
 

--- a/src/test/unit/unit_tests_tcp_ack.c
+++ b/src/test/unit/unit_tests_tcp_ack.c
@@ -1670,6 +1670,9 @@ START_TEST(test_arp_flush_pending_ttl_expired)
     arp_queue_packet(&s, TEST_SECOND_IF, dest_ip, &ip, (uint32_t)(ETH_HEADER_LEN + IP_HEADER_LEN));
     ck_assert_uint_eq(s.arp_pending[0].dest, dest_ip);
 
+    /* The store (and thus the flush) now requires a pending request we sent. */
+    arp_pending_record(&s, TEST_SECOND_IF, dest_ip);
+
     memset(&arp_reply, 0, sizeof(arp_reply));
     arp_reply.htype = ee16(1);
     arp_reply.ptype = ee16(0x0800);

--- a/src/test/unit/unit_tests_tcp_ack.c
+++ b/src/test/unit/unit_tests_tcp_ack.c
@@ -2169,20 +2169,148 @@ END_TEST
 START_TEST(test_arp_store_neighbor_no_space)
 {
     struct wolfIP s;
-    uint8_t mac[6] = {1, 2, 3, 4, 5, 6};
+    uint8_t mac[6] = {0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C};
     int i;
 
     wolfIP_init(&s);
     mock_link_init(&s);
 
+    /* Fill the table with distinct ages; slot 0 is the least recently used. */
     for (i = 0; i < MAX_NEIGHBORS; i++) {
         s.arp.neighbors[i].ip = (ip4)(0x0A000100U + (uint32_t)i);
         s.arp.neighbors[i].if_idx = TEST_PRIMARY_IF;
         memcpy(s.arp.neighbors[i].mac, "\x00\x00\x00\x00\x00\x00", 6);
+        s.arp.neighbors[i].ts = 1000U + (uint64_t)i * 1000U;
     }
+    s.last_tick = 50000U;
 
     arp_store_neighbor(&s, TEST_PRIMARY_IF, 0x0A0000A1U, mac);
-    ck_assert_uint_ne(s.arp.neighbors[0].ip, IPADDR_ANY);
+
+    /* A full table evicts the least recently used entry and installs the
+     * new neighbor in its place — MAX_NEIGHBORS is a working-set size, not
+     * a ceiling (F-6212). */
+    ck_assert_uint_eq(s.arp.neighbors[0].ip, 0x0A0000A1U);
+    ck_assert_mem_eq(s.arp.neighbors[0].mac, mac, 6);
+    ck_assert_uint_eq(s.arp.neighbors[0].ts, s.last_tick);
+    /* The rest of the working set survives. */
+    for (i = 1; i < MAX_NEIGHBORS; i++)
+        ck_assert_uint_eq(s.arp.neighbors[i].ip, (ip4)(0x0A000100U + (uint32_t)i));
+}
+END_TEST
+
+/* Full table + a solicited reply: the reply still installs, evicting the
+ * least recently used entry (the F-6212 flood lockout, end to end). */
+START_TEST(test_arp_full_table_solicited_reply_installs_via_eviction)
+{
+    struct wolfIP s;
+    struct arp_packet arp_reply;
+    struct wolfIP_ll_dev *ll;
+    ip4 legit_ip = 0x0A0000FEU;
+    uint8_t legit_mac[6] = {0x02, 0xCA, 0xFE, 0xBA, 0xBE, 0x01};
+    int i;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+
+    ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+
+    for (i = 0; i < MAX_NEIGHBORS; i++) {
+        s.arp.neighbors[i].ip = (ip4)(0x0A000100U + (uint32_t)i);
+        s.arp.neighbors[i].if_idx = TEST_PRIMARY_IF;
+        memcpy(s.arp.neighbors[i].mac, "\x00\x00\x00\x00\x00\x00", 6);
+        s.arp.neighbors[i].ts = 1000U + (uint64_t)i * 1000U;
+    }
+    s.last_tick = 50000U;
+    ck_assert_int_lt(arp_neighbor_index(&s, TEST_PRIMARY_IF, legit_ip), 0);
+
+    /* We asked for legit_ip and the owner answers. */
+    arp_pending_record(&s, TEST_PRIMARY_IF, legit_ip);
+
+    memset(&arp_reply, 0, sizeof(arp_reply));
+    memcpy(arp_reply.eth.dst, ll->mac, 6);
+    memcpy(arp_reply.eth.src, legit_mac, 6);
+    arp_reply.eth.type = ee16(ETH_TYPE_ARP);
+    arp_reply.htype    = ee16(1);
+    arp_reply.ptype    = ee16(0x0800);
+    arp_reply.hlen     = 6;
+    arp_reply.plen     = 4;
+    arp_reply.opcode   = ee16(ARP_REPLY);
+    memcpy(arp_reply.sma, legit_mac, 6);
+    arp_reply.sip      = ee32(legit_ip);
+    arp_reply.tip      = ee32(0x0A000001U);
+
+    arp_recv(&s, TEST_PRIMARY_IF, &arp_reply, sizeof(arp_reply));
+
+    /* Installed with the owner's MAC, evicting slot 0 (oldest). */
+    ck_assert_int_gt(arp_neighbor_index(&s, TEST_PRIMARY_IF, legit_ip), -1);
+    ck_assert_uint_eq(s.arp.neighbors[0].ip, legit_ip);
+    ck_assert_mem_eq(s.arp.neighbors[0].mac, legit_mac, 6);
+    for (i = 1; i < MAX_NEIGHBORS; i++)
+        ck_assert_uint_eq(s.arp.neighbors[i].ip, (ip4)(0x0A000100U + (uint32_t)i));
+}
+END_TEST
+
+/* Use-based aging: a successful lookup refreshes the entry's timestamp, so
+ * a live conversation never ages out even past ARP_AGING_TIMEOUT_MS since
+ * the original install. */
+START_TEST(test_arp_lookup_refreshes_ts_use_based_aging)
+{
+    struct wolfIP s;
+    uint8_t mac[6] = {0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0x01};
+    ip4 ip = 0x0A000020U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+
+    s.arp.neighbors[0].ip = ip;
+    s.arp.neighbors[0].if_idx = TEST_PRIMARY_IF;
+    memcpy(s.arp.neighbors[0].mac, mac, 6);
+    s.arp.neighbors[0].ts = 0;
+
+    /* Lookup just inside the aging window: alive, ts refreshed. */
+    s.last_tick = ARP_AGING_TIMEOUT_MS - 1;
+    ck_assert_int_gt(arp_neighbor_index(&s, TEST_PRIMARY_IF, ip), -1);
+    ck_assert_uint_eq(s.arp.neighbors[0].ts, s.last_tick);
+
+    /* Far past the original install's timeout, but within the window of
+     * the refresh: still alive. Without the refresh it would be gone. */
+    s.last_tick = (ARP_AGING_TIMEOUT_MS - 1) + (ARP_AGING_TIMEOUT_MS - 1);
+    ck_assert_int_gt(arp_neighbor_index(&s, TEST_PRIMARY_IF, ip), -1);
+}
+END_TEST
+
+/* Exact aging boundary (F-2320): age == ARP_AGING_TIMEOUT_MS is still
+ * live; age == ARP_AGING_TIMEOUT_MS + 1 evicts. Two entries so the
+ * boundary lookup on the first does not refresh the second. */
+START_TEST(test_arp_aging_exact_boundary)
+{
+    struct wolfIP s;
+    uint8_t mac[6] = {0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0x02};
+    ip4 ip_live  = 0x0A000030U;
+    ip4 ip_dead  = 0x0A000031U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+
+    s.arp.neighbors[0].ip = ip_live;
+    s.arp.neighbors[0].if_idx = TEST_PRIMARY_IF;
+    memcpy(s.arp.neighbors[0].mac, mac, 6);
+    s.arp.neighbors[0].ts = 0;
+    s.arp.neighbors[1].ip = ip_dead;
+    s.arp.neighbors[1].if_idx = TEST_PRIMARY_IF;
+    memcpy(s.arp.neighbors[1].mac, mac, 6);
+    s.arp.neighbors[1].ts = 0;
+
+    /* age == ARP_AGING_TIMEOUT_MS: not greater, still live. */
+    s.last_tick = ARP_AGING_TIMEOUT_MS;
+    ck_assert_int_gt(arp_neighbor_index(&s, TEST_PRIMARY_IF, ip_live), -1);
+
+    /* age == ARP_AGING_TIMEOUT_MS + 1: evicted and cleared. */
+    s.last_tick = ARP_AGING_TIMEOUT_MS + 1;
+    ck_assert_int_lt(arp_neighbor_index(&s, TEST_PRIMARY_IF, ip_dead), 0);
+    ck_assert_uint_eq(s.arp.neighbors[1].ip, IPADDR_ANY);
+    ck_assert_uint_eq(s.arp.neighbors[1].ts, 0);
 }
 END_TEST
 

--- a/src/test/unit/unit_tests_tcp_state.c
+++ b/src/test/unit/unit_tests_tcp_state.c
@@ -2629,3 +2629,190 @@ START_TEST(test_accept_synack_retransmit_repeats_isn)
     }
 }
 END_TEST
+
+/* ---- listener TX FIFO must not leak segments into the next connection ---- */
+
+START_TEST(test_accept_clears_listener_tx_fifo)
+{
+    struct wolfIP s;
+    int listen_sd;
+    struct tsocket *listener;
+    struct tsocket *accepted;
+    struct wolfIP_sockaddr_in sin;
+    int acc_sd;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    listen_sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, WI_IPPROTO_TCP);
+    ck_assert_int_gt(listen_sd, 0);
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = ee16(1234);
+    sin.sin_addr.s_addr = ee32(0x0A000001U);
+    ck_assert_int_eq(wolfIP_sock_bind(&s, listen_sd,
+            (struct wolfIP_sockaddr *)&sin, sizeof(sin)), 0);
+    ck_assert_int_eq(wolfIP_sock_listen(&s, listen_sd, 1), 0);
+    listener = &s.tcpsockets[SOCKET_UNMARK(listen_sd)];
+
+    /* Peer SYN: the listener goes SYN_RCVD and parks its SYN-ACK (the
+     * neighbor is unresolved under the pending-only ARP policy). */
+    inject_tcp_syn(&s, TEST_PRIMARY_IF, 0x0A000001U, 1234);
+    wolfIP_poll(&s, 1000);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
+    ck_assert_int_eq(fifo_is_empty(&listener->sock.tcp.txbuf), 0);
+
+    /* accept() hands the handshake to the clone; the listener must revert
+     * to LISTEN with an empty TX FIFO. */
+    acc_sd = wolfIP_sock_accept(&s, listen_sd, NULL, 0);
+    ck_assert_int_gt(acc_sd, 0);
+    accepted = &s.tcpsockets[SOCKET_UNMARK(acc_sd)];
+    ck_assert_int_eq(accepted->sock.tcp.state, TCP_SYN_RCVD);
+    /* The clone carries the connection's SYN-ACK. */
+    ck_assert_int_eq(fifo_is_empty(&accepted->sock.tcp.txbuf), 0);
+    /* The listener's parked SYN-ACK belongs to the abandoned half-open
+     * connection and must be dropped. */
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_LISTEN);
+    ck_assert_int_eq(fifo_is_empty(&listener->sock.tcp.txbuf), 1);
+}
+END_TEST
+
+START_TEST(test_rst_listener_fallback_clears_tx_fifo)
+{
+    struct wolfIP s;
+    int listen_sd;
+    struct tsocket *listener;
+    struct wolfIP_sockaddr_in sin;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    listen_sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, WI_IPPROTO_TCP);
+    ck_assert_int_gt(listen_sd, 0);
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = ee16(1234);
+    sin.sin_addr.s_addr = ee32(0x0A000001U);
+    ck_assert_int_eq(wolfIP_sock_bind(&s, listen_sd,
+            (struct wolfIP_sockaddr *)&sin, sizeof(sin)), 0);
+    ck_assert_int_eq(wolfIP_sock_listen(&s, listen_sd, 1), 0);
+    listener = &s.tcpsockets[SOCKET_UNMARK(listen_sd)];
+
+    /* Peer SYN, SYN-ACK parked as in test_accept_clears_listener_tx_fifo. */
+    inject_tcp_syn(&s, TEST_PRIMARY_IF, 0x0A000001U, 1234);
+    wolfIP_poll(&s, 1000);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
+    ck_assert_int_eq(fifo_is_empty(&listener->sock.tcp.txbuf), 0);
+
+    /* Peer RST with seq == rcv_nxt tears down the half-open connection; the
+     * listener falls back to LISTEN with an empty TX FIFO. */
+    inject_tcp_segment(&s, TEST_PRIMARY_IF, 0x0A0000A1U, 0x0A000001U, 40000, 1234,
+            listener->sock.tcp.ack, 0, TCP_FLAG_RST);
+    wolfIP_poll(&s, 1100);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_LISTEN);
+    ck_assert_int_eq(fifo_is_empty(&listener->sock.tcp.txbuf), 1);
+}
+END_TEST
+
+START_TEST(test_no_stale_synack_after_accept_new_conn)
+{
+    struct wolfIP s;
+    int listen_sd;
+    struct tsocket *listener;
+    struct wolfIP_sockaddr_in sin;
+    int acc_sd;
+    uint32_t count_before;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    listen_sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, WI_IPPROTO_TCP);
+    ck_assert_int_gt(listen_sd, 0);
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = ee16(1234);
+    sin.sin_addr.s_addr = ee32(0x0A000001U);
+    ck_assert_int_eq(wolfIP_sock_bind(&s, listen_sd,
+            (struct wolfIP_sockaddr *)&sin, sizeof(sin)), 0);
+    ck_assert_int_eq(wolfIP_sock_listen(&s, listen_sd, 1), 0);
+    listener = &s.tcpsockets[SOCKET_UNMARK(listen_sd)];
+
+    /* Connection A: SYN parked behind unresolved ARP. */
+    inject_tcp_syn(&s, TEST_PRIMARY_IF, 0x0A000001U, 1234);
+    wolfIP_poll(&s, 1000);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
+    acc_sd = wolfIP_sock_accept(&s, listen_sd, NULL, 0);
+    ck_assert_int_gt(acc_sd, 0);
+
+    /* Connection B: a second client port from the same peer while A's
+     * SYN-ACK is still parked. */
+    {
+        struct wolfIP_tcp_seg syn;
+        struct wolfIP_ll_dev *ll = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+        union transport_pseudo_header ph;
+        static const uint8_t src_mac[6] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
+
+        ck_assert_ptr_nonnull(ll);
+        memset(&syn, 0, sizeof(syn));
+        memcpy(syn.ip.eth.dst, ll->mac, 6);
+        memcpy(syn.ip.eth.src, src_mac, 6);
+        syn.ip.eth.type = ee16(ETH_TYPE_IP);
+        syn.ip.ver_ihl = 0x45;
+        syn.ip.ttl = 64;
+        syn.ip.proto = WI_IPPROTO_TCP;
+        syn.ip.len = ee16(IP_HEADER_LEN + TCP_HEADER_LEN);
+        syn.ip.src = ee32(0x0A0000A1U);
+        syn.ip.dst = ee32(0x0A000001U);
+        syn.ip.csum = 0;
+        iphdr_set_checksum(&syn.ip);
+        syn.src_port = ee16(40001);
+        syn.dst_port = ee16(1234);
+        syn.seq = ee32(7);
+        syn.ack = 0;
+        syn.hlen = TCP_HEADER_LEN << 2;
+        syn.flags = TCP_FLAG_SYN;
+        syn.win = ee16(65535);
+        syn.csum = 0;
+        syn.urg = 0;
+        memset(&ph, 0, sizeof(ph));
+        ph.ph.src = syn.ip.src;
+        ph.ph.dst = syn.ip.dst;
+        ph.ph.proto = 0x06;
+        ph.ph.len = ee16(TCP_HEADER_LEN);
+        syn.csum = ee16(transport_checksum(&ph, &syn.src_port));
+        tcp_input(&s, TEST_PRIMARY_IF, &syn,
+                sizeof(struct wolfIP_eth_frame) + IP_HEADER_LEN + TCP_HEADER_LEN);
+    }
+    wolfIP_poll(&s, 1200);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
+
+    /* Resolve the ARP (answer our own request) and flush. Exactly two
+     * SYN-ACKs may go out: the clone's for A and the listener's for B. A
+     * stale SYN-ACK from A's abandoned half-open state would be a third
+     * frame carrying A's destination port with B's ack value. */
+    {
+        struct arp_packet reply;
+        struct wolfIP_ll_dev *ll2 = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+        static const uint8_t peer_mac[6] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
+
+        ck_assert_ptr_nonnull(ll2);
+        memset(&reply, 0, sizeof(reply));
+        memcpy(reply.eth.dst, ll2->mac, 6);
+        memcpy(reply.eth.src, peer_mac, 6);
+        reply.eth.type = ee16(ETH_TYPE_ARP);
+        reply.htype = ee16(1);
+        reply.ptype = ee16(0x0800);
+        reply.hlen = 6;
+        reply.plen = 4;
+        reply.opcode = ee16(ARP_REPLY);
+        memcpy(reply.sma, peer_mac, 6);
+        reply.sip = ee32(0x0A0000A1U);
+        memcpy(reply.tma, ll2->mac, 6);
+        reply.tip = ee32(0x0A000001U);
+        arp_recv(&s, TEST_PRIMARY_IF, &reply, sizeof(reply));
+    }
+    count_before = last_frame_sent_count;
+    wolfIP_poll(&s, 1300);
+    ck_assert_uint_eq(last_frame_sent_count - count_before, 2U);
+}
+END_TEST

--- a/src/test/unit/unit_tests_tcp_state.c
+++ b/src/test/unit/unit_tests_tcp_state.c
@@ -2558,6 +2558,33 @@ START_TEST(test_accept_synack_retransmit_repeats_isn)
     /* Peer SYN triggers passive open; the SYN-ACK carries the clone's ISN. */
     inject_tcp_syn(&s, TEST_PRIMARY_IF, 0x0A000001U, 1234);
     wolfIP_poll(&s, 1000);
+    /* The SYN-ACK is held behind ARP resolution: the stack no longer learns
+     * the neighbor from the incoming SYN (pending-only policy), so the flush
+     * sent an ARP request for 10.0.0.161 and parked the segment. Answer our
+     * own request — the peer's MAC is the one inject_tcp_syn used — so the
+     * pending SYN-ACK can actually go out. */
+    {
+        struct arp_packet reply;
+        struct wolfIP_ll_dev *ll2 = wolfIP_getdev_ex(&s, TEST_PRIMARY_IF);
+        static const uint8_t peer_mac[6] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
+
+        ck_assert_ptr_nonnull(ll2);
+        memset(&reply, 0, sizeof(reply));
+        memcpy(reply.eth.dst, ll2->mac, 6);
+        memcpy(reply.eth.src, peer_mac, 6);
+        reply.eth.type = ee16(ETH_TYPE_ARP);
+        reply.htype = ee16(1);
+        reply.ptype = ee16(0x0800);
+        reply.hlen = 6;
+        reply.plen = 4;
+        reply.opcode = ee16(ARP_REPLY);
+        memcpy(reply.sma, peer_mac, 6);
+        reply.sip = ee32(0x0A0000A1U);
+        memcpy(reply.tma, ll2->mac, 6);
+        reply.tip = ee32(0x0A000001U);
+        arp_recv(&s, TEST_PRIMARY_IF, &reply, sizeof(reply));
+        wolfIP_poll(&s, 1050);
+    }
     for (i = 0; i < MAX_TCPSOCKETS; i++) {
         if (s.tcpsockets[i].sock.tcp.state == TCP_SYN_RCVD) {
             syn_rcvd = &s.tcpsockets[i];

--- a/src/test/unit/unit_tests_vlan.c
+++ b/src/test/unit/unit_tests_vlan.c
@@ -1462,6 +1462,13 @@ START_TEST(test_vlan_rx_unfiltered_arp_reply_learns_neighbor)
                                  100, 0, 0);
     ck_assert_uint_gt(tagged_len, 0u);
 
+    /* The pending-only policy installs neighbors only in answer to a
+     * request we sent, so ask for the address first; the VLAN RX path must
+     * still deliver the tagged reply to the subinterface's arp_recv.
+     * last_tick advances past the 1 req/s rate-limit window that a fresh
+     * stack (last_arp = 0, tick = 0) would still be in. */
+    s.last_tick = 1000U;
+    arp_request(&s, sub_idx, VLAN_REMOTE_IP);
     wolfIP_recv_on(&s, TEST_PRIMARY_IF, tagged, tagged_len);
 
     memset(mac, 0, sizeof(mac));

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8860,19 +8860,20 @@ static void arp_recv(struct wolfIP *s, unsigned int if_idx, void *buf, int len)
     }
     else if (arp->opcode == ee16(ARP_REPLY)) {
         ip4 sip = ee32(arp->sip);
-        int idx, pending;
+        int pending;
         /* Validate sender IP: reject broadcast, multicast, zero, and
          * our own address -- same checks as the ARP request handler. */
         if (sip == IPADDR_ANY || sip == conf->ip ||
                 wolfIP_ip_is_broadcast(s, sip) ||
                 wolfIP_ip_is_multicast(sip))
             return;
-        idx = arp_neighbor_index(s, if_idx, sip);
         pending = arp_pending_match_and_clear(s, if_idx, sip);
-        /* Security trade-off: allow quick-path add, but block unsolicited overwrite. */
-        if (pending || idx < 0) {
+        /* A neighbor entry is installed or updated only in answer to a
+         * request we ourselves sent (pending match). Unsolicited replies —
+         * GARP, pre-poisoning, first-install of a stranger — never touch
+         * the table. */
+        if (pending)
             arp_store_neighbor(s, if_idx, sip, arp->sma);
-        }
     }
 }
 

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -1049,6 +1049,7 @@ static int wolfIP_filter_notify_icmp(enum wolfIP_filter_reason reason,
 #define DHCP_REQUEST 3
 #define DHCP_ACK 5
 #define DHCP_NAK 6
+#define DHCP_DECLINE 7
 
 #define DHCP_MAGIC 0x63825363
 #define DHCP_SERVER_PORT 67
@@ -1075,6 +1076,10 @@ static int wolfIP_filter_notify_icmp(enum wolfIP_filter_reason reason,
 /* RFC 2131 §4.1: retransmission delay doubles each attempt up to a 64s ceiling. */
 #define DHCP_BACKOFF_MAX_MS 64000U
 
+/* RFC 4331 / RFC 5227: probe the address after a DHCPACK before using it. */
+#define DHCP_DAD_PROBES 3
+#define DHCP_DAD_INTERVAL_MS 1000U
+
 enum dhcp_state {
     DHCP_OFF = 0,
     DHCP_DISCOVER_SENT,
@@ -1082,6 +1087,7 @@ enum dhcp_state {
     DHCP_BOUND,
     DHCP_RENEWING,
     DHCP_REBINDING,
+    DHCP_DAD, /* RFC 4331: probing the address received in a DHCPACK */
 };
 
 #define DHCP_IS_RUNNING(s) \
@@ -1367,6 +1373,7 @@ struct wolfIP {
     int dhcp_udp_sd; /* DHCP socket descriptor. DHCP uses an UDP socket */
     uint32_t dhcp_timer; /* Timer for DHCP */
     uint32_t dhcp_timeout_count; /* DHCP timeout counter */
+    uint8_t dhcp_dad_probes; /* DAD probes sent (0 = DAD inactive) */
     ip4 dhcp_server_ip; /* DHCP server IP */
     ip4 dhcp_ip; /* IP address assigned by DHCP */
     uint64_t dhcp_renew_at; /* Renewal time (T1) */
@@ -7804,6 +7811,10 @@ static void icmp_input(struct wolfIP *s, unsigned int if_idx, struct wolfIP_ip_p
 
 static int dhcp_send_discover(struct wolfIP *s);
 static int dhcp_send_request(struct wolfIP *s);
+#ifdef ETHERNET
+static int dhcp_send_dad_probe(struct wolfIP *s);
+#endif
+static void dhcp_dad_conflict(struct wolfIP *s);
 static void dhcp_timer_cb(void *arg);
 static void dhcp_cancel_timer(struct wolfIP *s);
 static void dhcp_deconfigure_lease(struct wolfIP *s);
@@ -7976,6 +7987,27 @@ static void dhcp_timer_cb(void *arg)
             if (ret >= 0)
                 s->dhcp_timeout_count++;
             break;
+#ifdef ETHERNET
+        case DHCP_DAD:
+            if (s->dhcp_dad_probes < DHCP_DAD_PROBES) {
+                if (dhcp_send_dad_probe(s) < 0) {
+                    /* Probe could not be sent; retry on the next tick. */
+                    dhcp_schedule_timer_at(s,
+                            s->last_tick + 1);
+                    break;
+                }
+                s->dhcp_dad_probes++;
+                dhcp_schedule_timer_at(s,
+                        s->last_tick + DHCP_DAD_INTERVAL_MS);
+            } else {
+                /* All probes unanswered: the address is ours. The lease
+                 * timers were armed when the ACK was parsed. */
+                s->dhcp_dad_probes = 0;
+                s->dhcp_state = DHCP_BOUND;
+                dhcp_schedule_timer_at(s, s->dhcp_renew_at);
+            }
+            break;
+#endif
         default:
             break;
     }
@@ -8296,8 +8328,24 @@ static int dhcp_parse_ack(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_l
                 if (primary && saw_server_id && lease_s != 0 &&
                     (primary->ip != 0) && (primary->mask != 0)) {
                     dhcp_cancel_timer(s);
+                    s->dhcp_ip = primary->ip;
+#ifdef ETHERNET
+                    /* RFC 4331: probe the address before using it. The
+                     * lease timers are armed now so they are in place when
+                     * the probes complete; the short DAD timer overrides
+                     * them until then. A conflicting answer is detected in
+                     * arp_recv (dhcp_dad_conflict). */
+                    s->dhcp_state = DHCP_DAD;
+                    s->dhcp_dad_probes = 0;
+                    dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
+                    if (dhcp_send_dad_probe(s) == 0)
+                        s->dhcp_dad_probes = 1;
+                    dhcp_schedule_timer_at(s,
+                            s->last_tick + DHCP_DAD_INTERVAL_MS);
+#else
                     s->dhcp_state = DHCP_BOUND;
                     dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
+#endif
                     return 0;
                 }
             }
@@ -8570,6 +8618,68 @@ int dhcp_client_init(struct wolfIP *s)
     return dhcp_send_discover(s);
 }
 
+/* RFC 2131 §4.4: DECLINE — sent when the client detects that the address
+ * in a received DHCPACK is already in use on the link. */
+static int dhcp_send_decline(struct wolfIP *s)
+{
+    struct dhcp_msg dec;
+    struct dhcp_option *opt = (struct dhcp_option *)(dec.options);
+    struct wolfIP_sockaddr_in sin;
+    uint32_t opt_sz = 0;
+
+    if (!s || s->dhcp_udp_sd <= 0)
+        return -1;
+
+    memset(&dec, 0, sizeof(struct dhcp_msg));
+    dec.op = BOOT_REQUEST;
+    dec.htype = 1; /* Ethernet */
+    dec.hlen = 6; /* MAC */
+    dec.xid = ee32(s->dhcp_xid);
+    dec.ciaddr = ee32(s->dhcp_ip); /* the address being declined */
+    dec.secs = ee16(dhcp_elapsed_secs(s));
+    dec.magic = ee32(DHCP_MAGIC);
+    {
+        struct wolfIP_ll_dev *ll = wolfIP_ll_at(s, WOLFIP_PRIMARY_IF_IDX);
+        if (ll)
+            memcpy(dec.chaddr, ll->mac, 6);
+    }
+
+    memset(dec.options, 0xFF, sizeof(dec.options));
+    opt->code = DHCP_OPTION_MSG_TYPE;
+    opt->len = 1;
+    opt->data[0] = DHCP_DECLINE;
+    opt_sz += 3;
+    opt = (struct dhcp_option *)((uint8_t *)opt + 3);
+    if (s->dhcp_server_ip != 0) {
+        opt->code = DHCP_OPTION_SERVER_ID;
+        opt->len = 4;
+        DHCP_OPT_u32_to_data(opt, s->dhcp_server_ip);
+        opt_sz += 6;
+    }
+    opt_sz++; /* END marker */
+
+    memset(&sin, 0, sizeof(struct wolfIP_sockaddr_in));
+    sin.sin_port = ee16(DHCP_SERVER_PORT);
+    sin.sin_addr.s_addr = ee32(0xFFFFFFFF); /* Broadcast */
+    sin.sin_family = AF_INET;
+    return wolfIP_sock_sendto(s, s->dhcp_udp_sd, &dec, DHCP_HEADER_LEN + opt_sz, 0,
+            (struct wolfIP_sockaddr *)&sin, sizeof(struct wolfIP_sockaddr_in));
+}
+
+/* A DAD probe was answered by a host other than us: the address is in
+ * use. RFC 4331: decline it and restart address configuration. */
+static void dhcp_dad_conflict(struct wolfIP *s)
+{
+    /* Decline first: it carries the address, which deconfigure erases. */
+    dhcp_send_decline(s);
+    s->dhcp_dad_probes = 0;
+    dhcp_cancel_timer(s);
+    dhcp_deconfigure_lease(s);
+    s->dhcp_state = DHCP_OFF;
+    s->dhcp_timeout_count = 0;
+    dhcp_send_discover(s);
+}
+
 /* ARP */
 #ifdef ETHERNET
 
@@ -8806,6 +8916,40 @@ static void arp_request(struct wolfIP *s, unsigned int if_idx, ip4 tip)
     wolfIP_ll_send_frame(s, if_idx, &arp, sizeof(struct arp_packet));
 }
 
+/* RFC 4331 §2.1 DAD probe: an ARP request with sip = 0.0.0.0 and tip =
+ * the address being tested. A host that owns the address answers it; the
+ * reply is detected in arp_recv (dhcp_dad_conflict). Deliberately bypasses
+ * the 1 req/s rate limit: DAD is at most 3 probes per acquisition, one
+ * per second, and must not starve behind ordinary traffic. */
+static int dhcp_send_dad_probe(struct wolfIP *s)
+{
+    struct arp_packet arp;
+    struct wolfIP_ll_dev *ll;
+    struct ipconf *primary;
+
+    ll = wolfIP_ll_at(s, WOLFIP_PRIMARY_IF_IDX);
+    if (!ll || ll->non_ethernet)
+        return -1;
+    primary = wolfIP_ipconf_at(s, WOLFIP_PRIMARY_IF_IDX);
+    if (!primary || primary->ip == IPADDR_ANY)
+        return -1;
+
+    memset(&arp, 0, sizeof(arp));
+    eth_output_add_header(s, WOLFIP_PRIMARY_IF_IDX, NULL, &arp.eth,
+                          ETH_TYPE_ARP);
+    arp.htype  = ee16(1); /* Ethernet */
+    arp.ptype  = ee16(0x0800);
+    arp.hlen   = 6;
+    arp.plen   = 4;
+    arp.opcode = ee16(ARP_REQUEST);
+    memcpy(arp.sma, ll->mac, 6);
+    arp.sip    = ee32(IPADDR_ANY); /* RFC 4331: sender IP is 0.0.0.0 */
+    memset(arp.tma, 0, 6);
+    arp.tip    = ee32(primary->ip);
+    return wolfIP_ll_send_frame(s, WOLFIP_PRIMARY_IF_IDX, &arp,
+                                sizeof(struct arp_packet));
+}
+
 static void arp_recv(struct wolfIP *s, unsigned int if_idx, void *buf, int len)
 {
     struct arp_packet *arp = (struct arp_packet *)buf;
@@ -8863,6 +9007,14 @@ static void arp_recv(struct wolfIP *s, unsigned int if_idx, void *buf, int len)
     else if (arp->opcode == ee16(ARP_REPLY)) {
         ip4 sip = ee32(arp->sip);
         int pending;
+        /* RFC 4331 DAD: a reply claiming the address being probed means
+         * it is in use, unless it came from our own MAC (looped probe).
+         * This is the one case where a reply for our own IP is acted on. */
+        if (s->dhcp_state == DHCP_DAD && sip == conf->ip) {
+            if (memcmp(arp->sma, ll->mac, 6) != 0)
+                dhcp_dad_conflict(s);
+            return;
+        }
         /* Validate sender IP: reject broadcast, multicast, zero, and
          * our own address -- same checks as the ARP request handler. */
         if (sip == IPADDR_ANY || sip == conf->ip ||

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8572,7 +8572,10 @@ static int dhcp_parse_ack(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_l
                     dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
                     timer_binheap_cancel(&s->timers, s->dhcp_timer);
                     s->dhcp_timer = NO_TIMER;
-                    if (dhcp_send_dad_probe(s) == 0)
+                    /* ll drivers return the frame length (>= 0) on
+                     * success, not 0; only count the probe when it
+                     * actually went out. */
+                    if (dhcp_send_dad_probe(s) >= 0)
                         s->dhcp_dad_probes = 1;
                     dhcp_schedule_timer_at(s,
                             s->last_tick + DHCP_DAD_INTERVAL_MS);

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8653,39 +8653,44 @@ static void arp_store_neighbor(struct wolfIP *s, unsigned int if_idx, ip4 ip,
                                const uint8_t *mac)
 {
     int i;
-    int stored = 0;
+    int slot = -1;
     if (!s)
         return;
     for (i = 0; i < MAX_NEIGHBORS; i++) {
         if (s->arp.neighbors[i].ip == ip && s->arp.neighbors[i].if_idx == if_idx) {
-            memcpy(s->arp.neighbors[i].mac, mac, 6);
-            s->arp.neighbors[i].ts = s->last_tick;
-            stored = 1;
+            slot = i;
             break;
         }
+        if (slot < 0 && s->arp.neighbors[i].ip == IPADDR_ANY)
+            slot = i;
     }
-    if (!stored) {
-        for (i = 0; i < MAX_NEIGHBORS; i++) {
-            if (s->arp.neighbors[i].ip == IPADDR_ANY) {
-                s->arp.neighbors[i].ip = ip;
-                s->arp.neighbors[i].if_idx = (uint8_t)if_idx;
-                memcpy(s->arp.neighbors[i].mac, mac, 6);
-                s->arp.neighbors[i].ts = s->last_tick;
-                stored = 1;
-                break;
+    if (slot < 0) {
+        /* Table full: evict the least recently used entry. MAX_NEIGHBORS is
+         * a working-set size, not a ceiling — a flood can churn the cache
+         * but never lock out resolution of a live peer (F-6212). */
+        uint64_t oldest_ts = s->arp.neighbors[0].ts;
+        slot = 0;
+        for (i = 1; i < MAX_NEIGHBORS; i++) {
+            if (s->arp.neighbors[i].ts < oldest_ts) {
+                oldest_ts = s->arp.neighbors[i].ts;
+                slot = i;
             }
         }
     }
-    if (stored) {
+    s->arp.neighbors[slot].ip = ip;
+    s->arp.neighbors[slot].if_idx = (uint8_t)if_idx;
+    memcpy(s->arp.neighbors[slot].mac, mac, 6);
+    s->arp.neighbors[slot].ts = s->last_tick;
 #if WOLFIP_ENABLE_FORWARDING
-        arp_flush_pending(s, if_idx, ip);
+    arp_flush_pending(s, if_idx, ip);
 #endif
-    }
 }
 
 /* Lookup neighbor entry by IP/interface.
  * Returns the index, or -1 if not found.
  * If the entry has aged out, it is evicted and -1 is returned.
+ * A successful lookup refreshes the timestamp (use-based aging): live
+ * conversations never age out, dead entries reclaim at the timeout.
  */
 static int arp_neighbor_index(struct wolfIP *s, unsigned int if_idx, ip4 ip)
 {
@@ -8702,6 +8707,7 @@ static int arp_neighbor_index(struct wolfIP *s, unsigned int if_idx, ip4 ip)
                 memset(s->arp.neighbors[i].mac, 0, 6);
                 return -1;
             }
+            s->arp.neighbors[i].ts = s->last_tick;
             return i;
         }
     }

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -5211,6 +5211,10 @@ static void tcp_input(struct wolfIP *S, unsigned int if_idx,
                         t->remote_ip = IPADDR_ANY;
                         t->dst_port = 0;
                         t->sock.tcp.ack = 0;
+                        /* Drop the RST'd connection's parked SYN-ACK; it must
+                         * not be retransmitted for the next connection (see
+                         * the accept() revert for why). */
+                        fifo_init(&t->sock.tcp.txbuf, t->txmem, TXBUF_SIZE);
                         continue;
                     }
                     /* An accepted (cloned) connection has no listen role: a peer
@@ -5548,6 +5552,10 @@ static void tcp_rto_cb(void *arg)
                 ts->remote_ip = 0;
                 ts->dst_port = 0;
                 ts->events = 0;
+                /* The timed-out SYN-ACK is gone with the connection; drop it
+                 * so the next connection starts with an empty TX FIFO (see
+                 * the accept() revert for why). */
+                fifo_init(&ts->sock.tcp.txbuf, ts->txmem, TXBUF_SIZE);
                 if (ts->bound_local_ip != IPADDR_ANY) {
                     int bound_match = 0;
                     unsigned int bound_if = wolfIP_if_for_local_ip(
@@ -6207,6 +6215,13 @@ int wolfIP_sock_accept(struct wolfIP *s, int sockfd, struct wolfIP_sockaddr *add
             }
             ts->sock.tcp.state = TCP_LISTEN;
             tcp_ctrl_rto_stop(ts);
+            /* The accepted connection owns the handshake now (its SYN-ACK
+             * lives in the clone's TX FIFO). Drop segments parked by the
+             * half-open connection: the flush refreshes a parked segment's
+             * ack from the socket's current state, so a stale SYN-ACK would
+             * be retransmitted for the listener's next connection with the
+             * new connection's ack value and a wrong destination port. */
+            fifo_init(&ts->sock.tcp.txbuf, ts->txmem, TXBUF_SIZE);
             ts->sock.tcp.seq = wolfIP_getrandom();
             if (ts->bound_local_ip != IPADDR_ANY) {
                 int bound_match = 0;

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -3385,7 +3385,10 @@ static int tcp_send_empty_immediate(struct tsocket *t, struct wolfIP_tcp_seg *tc
 
         if (arp_lookup(t->S, tx_if, nexthop, t->nexthop_mac) < 0) {
             arp_request(t->S, tx_if, nexthop);
-            return -1;
+            /* The segment (a pure ACK here) is retryable once the request
+             * resolves; report EAGAIN so the caller schedules the retry
+             * instead of dropping the segment (F-10261). */
+            return -WOLFIP_EAGAIN;
         }
     }
 #endif

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -9146,10 +9146,16 @@ static void arp_request(struct wolfIP *s, unsigned int if_idx, ip4 tip)
     if (!conf)
         return;
 
-    if (s->arp.last_arp[if_idx] + 1000 > s->last_tick) {
+    /* One request per second per interface. last_arp == 0 means "never
+     * sent" (fresh boot, or a tick-source restart that reset the limiter),
+     * so the first request is never held back by the window. */
+    if (s->arp.last_arp[if_idx] != 0 &&
+            s->arp.last_arp[if_idx] + 1000 > s->last_tick) {
         return;
     }
-    s->arp.last_arp[if_idx] = s->last_tick;
+    /* Store tick+1 so a request sent at tick 0 is distinguishable from
+     * "never sent" (last_arp == 0). */
+    s->arp.last_arp[if_idx] = s->last_tick + 1;
     memset(&arp, 0, sizeof(struct arp_packet));
     eth_output_add_header(s, if_idx, NULL, &arp.eth, ETH_TYPE_ARP);
     arp.htype = ee16(1); /* Ethernet */
@@ -11149,6 +11155,20 @@ int wolfIP_poll(struct wolfIP *s, uint64_t now)
 {
     if (!s)
         return -WOLFIP_EINVAL;
+
+#ifdef ETHERNET
+    if (now < s->last_tick) {
+        unsigned int i;
+        /* The tick source restarted from a lower value (e.g. the app
+         * handed off from a bare-metal tick loop to an RTOS tick). Absolute
+         * tick values from the previous domain are no longer comparable,
+         * so reset the ARP rate limit: otherwise a stale last_arp from the
+         * old domain holds the first request in the new domain for the
+         * whole stale offset. */
+        for (i = 0; i < s->if_count; i++)
+            s->arp.last_arp[i] = 0;
+    }
+#endif
 
     s->last_tick = now;
 

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -7813,8 +7813,8 @@ static int dhcp_send_discover(struct wolfIP *s);
 static int dhcp_send_request(struct wolfIP *s);
 #ifdef ETHERNET
 static int dhcp_send_dad_probe(struct wolfIP *s);
-#endif
 static void dhcp_dad_conflict(struct wolfIP *s);
+#endif
 static void dhcp_timer_cb(void *arg);
 static void dhcp_cancel_timer(struct wolfIP *s);
 static void dhcp_deconfigure_lease(struct wolfIP *s);
@@ -8337,7 +8337,14 @@ static int dhcp_parse_ack(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_l
                      * arp_recv (dhcp_dad_conflict). */
                     s->dhcp_state = DHCP_DAD;
                     s->dhcp_dad_probes = 0;
+                    /* Arm the lease absolutes, then swap the renew timer for
+                     * the DAD timer: handle_timers() fires every expired
+                     * entry, so leaving both in the heap would double-fire
+                     * the renew. The absolutes survive; the DAD completion
+                     * re-arms the renew timer. */
                     dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
+                    timer_binheap_cancel(&s->timers, s->dhcp_timer);
+                    s->dhcp_timer = NO_TIMER;
                     if (dhcp_send_dad_probe(s) == 0)
                         s->dhcp_dad_probes = 1;
                     dhcp_schedule_timer_at(s,
@@ -8618,8 +8625,10 @@ int dhcp_client_init(struct wolfIP *s)
     return dhcp_send_discover(s);
 }
 
+#ifdef ETHERNET
 /* RFC 2131 §4.4: DECLINE — sent when the client detects that the address
- * in a received DHCPACK is already in use on the link. */
+ * in a received DHCPACK is already in use on the link. Only sent from the
+ * DAD conflict path, which is ethernet-only. */
 static int dhcp_send_decline(struct wolfIP *s)
 {
     struct dhcp_msg dec;
@@ -8667,7 +8676,8 @@ static int dhcp_send_decline(struct wolfIP *s)
 }
 
 /* A DAD probe was answered by a host other than us: the address is in
- * use. RFC 4331: decline it and restart address configuration. */
+ * use. RFC 4331: decline it and restart address configuration. Only
+ * reachable from the arp_recv DAD hook, which is ethernet-only. */
 static void dhcp_dad_conflict(struct wolfIP *s)
 {
     /* Decline first: it carries the address, which deconfigure erases. */
@@ -8679,6 +8689,7 @@ static void dhcp_dad_conflict(struct wolfIP *s)
     s->dhcp_timeout_count = 0;
     dhcp_send_discover(s);
 }
+#endif
 
 /* ARP */
 #ifdef ETHERNET

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8877,7 +8877,9 @@ static int dhcp_send_decline(struct wolfIP *s)
     dec.htype = 1; /* Ethernet */
     dec.hlen = 6; /* MAC */
     dec.xid = ee32(s->dhcp_xid);
-    dec.ciaddr = ee32(s->dhcp_ip); /* the address being declined */
+    /* ciaddr stays 0.0.0.0: the client never bound the address. The
+     * declined address is carried in option 50 (Requested IP). */
+    dec.ciaddr = ee32(0);
     dec.secs = ee16(dhcp_elapsed_secs(s));
     dec.magic = ee32(DHCP_MAGIC);
     {
@@ -8897,7 +8899,13 @@ static int dhcp_send_decline(struct wolfIP *s)
         opt->len = 4;
         DHCP_OPT_u32_to_data(opt, s->dhcp_server_ip);
         opt_sz += 6;
+        opt = (struct dhcp_option *)((uint8_t *)opt + 6);
     }
+    /* RFC 2131 §4.4: carry the declined address in option 50. */
+    opt->code = DHCP_OPTION_OFFER_IP; /* Requested IP */
+    opt->len = 4;
+    DHCP_OPT_u32_to_data(opt, s->dhcp_ip);
+    opt_sz += 6;
     opt_sz++; /* END marker */
 
     memset(&sin, 0, sizeof(struct wolfIP_sockaddr_in));

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8594,7 +8594,7 @@ static void arp_queue_packet(struct wolfIP *s, unsigned int if_idx, ip4 dest,
             slot = i;
     }
     if (slot < 0)
-        slot = 0;
+        return; /* queue full: drop, upstream retransmits (F-4057) */
 
     memcpy(s->arp_pending[slot].frame, ip, len);
     s->arp_pending[slot].len = len;

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -5239,13 +5239,6 @@ static void tcp_input(struct wolfIP *S, unsigned int if_idx,
                     t->sock.tcp.snd_una = t->sock.tcp.seq;
                     t->dst_port = ee16(tcp->src_port);
                     t->remote_ip = ee32(tcp->ip.src);
-                    {
-                        unsigned int nh_if = if_idx;
-                        ip4 nh = wolfIP_select_nexthop_ex(S, &nh_if, t->remote_ip);
-                        if (!wolfIP_ll_is_non_ethernet(S, nh_if) &&
-                                arp_neighbor_index(S, nh_if, nh) < 0)
-                            arp_store_neighbor(S, nh_if, nh, tcp->ip.eth.src);
-                    }
                     t->events |= CB_EVENT_READABLE; /* Keep flag until application calls accept */
                     tcp_process_ts(t, tcp, frame_len);
                     tcp_send_syn(t, TCP_FLAG_SYN | TCP_FLAG_ACK);

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8825,6 +8825,11 @@ static void arp_recv(struct wolfIP *s, unsigned int if_idx, void *buf, int len)
         arp->hlen != 6 || arp->plen != 4)
         return;
 
+    /* Reject a broadcast/multicast sender MAC (group bit set): a group
+     * address cannot identify the unicast host an entry would bind to. */
+    if (arp->sma[0] & 0x01)
+        return;
+
     if (arp->opcode == ee16(ARP_REQUEST) && arp->tip == ee32(conf->ip)) {
         uint32_t sender_ip = arp->sip;
         uint8_t sender_mac[6];

--- a/tools/scripts/run-m33mu-ci-in-container.sh
+++ b/tools/scripts/run-m33mu-ci-in-container.sh
@@ -181,6 +181,21 @@ wait_for_lease() {
       ip="$(tail -n1 /tmp/dnsmasq.leases | cut -d' ' -f3)"
     fi
     if [ -n "${ip}" ]; then
+      # The host grants the lease at the DHCP ACK, but the device may still
+      # be running RFC 4331 DAD (3 probes) before it binds the address and
+      # starts serving. Under the emulated (paced) tick rate that window is
+      # several seconds, longer than a short nc retry burst, so the test
+      # would give up while the device is still legitimately probing. The
+      # plain app prints a ready line when it is bound; wait for it (other
+      # apps print no DHCP marker and keep the old behavior).
+      if grep -q "Starting DHCP client" /tmp/m33mu.log 2>/dev/null; then
+        for _ in $(seq 1 "${retries}"); do
+          if grep -q "DHCP configuration received" /tmp/m33mu.log 2>/dev/null; then
+            break
+          fi
+          sleep 1
+        done
+      fi
       printf '%s\n' "${ip}"
       return 0
     fi


### PR DESCRIPTION
Featuring the following addressed claims:

d146f2a F-4045: self-review fixes for the DAD state machine
d7d2199 F-4045: run RFC 4331 DAD after DHCPACK before the lease binds
64288da F-4057: drop queued frame when the ARP pending queue is full
9ba8611 F-10261: retry the pure ACK when the immediate send misses ARP
99fb19b F-6035: remove SYN-driven ARP neighbor learning
3c194d9 F-6212: evict the least recently used neighbor when the table is full
88c8feb F-9805: require a pending request for ARP reply installs
b5fd480 F-10274: drop ARP frames with a group sender MAC