### PR TITLE
Fenrir fixes 2026 08 24

### DIFF
--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -544,6 +544,9 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_utils, test_dhcp_parse_offer_option_overload);
     tcase_add_test(tc_utils,
                    test_dhcp_parse_offer_option_split_across_region_boundary_rejected);
+    tcase_add_test(tc_utils, test_dhcp_parse_offer_main_field_without_end_rejected);
+    tcase_add_test(tc_utils,
+                   test_dhcp_parse_offer_compliant_overloaded_offer_accepted);
     tcase_add_test(tc_utils, test_dhcp_discover_first_retry_delay_rfc2131);
     tcase_add_test(tc_utils, test_dhcp_discover_sets_broadcast_flag);
     tcase_add_test(tc_utils, test_dhcp_request_broadcast_flag_by_state);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1476,7 +1476,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_nak_relearns_dns_server);
     tcase_add_test(tc_core, test_dhcp_lease_expiry_keeps_pinned_dns_server);
     tcase_add_test(tc_core, test_dhcp_public_apis_null_stack_safe);
-    /* --- unit_tests_ip_arp_recv.c (35 tests) --- */
+    /* --- unit_tests_ip_arp_recv.c (38 tests) --- */
     tcase_add_test(tc_core, test_ip_recv_limited_broadcast_dst_is_local);
     tcase_add_test(tc_core, test_ip_recv_directed_broadcast_dst_is_local);
     tcase_add_test(tc_core, test_ip_recv_ipaddr_any_dst_is_local);
@@ -1489,6 +1489,9 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_ip_recv_forward_link_local_src_rpf_drop);
     tcase_add_test(tc_core, test_ip_recv_forward_self_ip_src_dropped);
     tcase_add_test(tc_core, test_ip_recv_l2_broadcast_frame_not_forwarded);
+    tcase_add_test(tc_core, test_ip_recv_forward_no_route_dropped_not_dispatched);
+    tcase_add_test(tc_core, test_ip_recv_l2_group_not_locally_deliverable_dropped);
+    tcase_add_test(tc_core, test_ip_recv_l2_group_dhcp_still_reaches_local_udp);
     tcase_add_test(tc_core, test_ip_recv_options_nop_delivered);
     tcase_add_test(tc_core, test_ip_recv_options_rr_stripped_and_delivered);
     tcase_add_test(tc_core, test_ip_recv_options_bad_length_aborts_parse);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -543,7 +543,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_utils, test_dns_callback_rejects_a_record_with_wrong_rdlength);
     tcase_add_test(tc_utils, test_dhcp_parse_offer_option_overload);
     tcase_add_test(tc_utils,
-                   test_dhcp_parse_offer_option_split_across_region_boundary);
+                   test_dhcp_parse_offer_option_split_across_region_boundary_rejected);
     tcase_add_test(tc_utils, test_dhcp_discover_first_retry_delay_rfc2131);
     tcase_add_test(tc_utils, test_dhcp_discover_sets_broadcast_flag);
     tcase_add_test(tc_utils, test_dhcp_request_broadcast_flag_by_state);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1438,11 +1438,13 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_msg_type_nak_absent_server_id_rejected);
     tcase_add_test(tc_core, test_dhcp_msg_type_nak_matching_server_id_accepted);
     tcase_add_test(tc_core, test_dhcp_parse_offer_type_ack_not_offer_rejected);
+    tcase_add_test(tc_core, test_dhcp_parse_offer_options_before_msg_type_accepted);
+    tcase_add_test(tc_core, test_dhcp_parse_offer_bad_server_id_before_msg_type_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_offer_subnet_mask_len_lt4_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_offer_inner_truncated_opt2_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_offer_inner_truncated_data_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_offer_inner_pad_then_end);
-    tcase_add_test(tc_core, test_dhcp_parse_offer_outer_end_with_state_already_set);
+    tcase_add_test(tc_core, test_dhcp_parse_offer_non_offer_with_stale_state_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_ack_mismatched_server_id_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_ack_server_id_len_lt4_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_ack_offer_ip_len_lt4_rejected);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -963,6 +963,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_proto, test_icmp_input_dest_unreach_port_unreachable_mismatched_orig_src_port_ignored);
     tcase_add_test(tc_proto, test_icmp_input_dest_unreach_port_unreachable_mismatched_orig_dst_port_ignored);
     tcase_add_test(tc_proto, test_udp_sendto_and_recvfrom);
+    tcase_add_test(tc_proto, test_udp_wildcard_bind_receives_all_local_addrs);
     tcase_add_test(tc_proto, test_udp_sendto_respects_mtu_api);
     tcase_add_test(tc_proto, test_udp_recvfrom_sets_remote_ip);
     tcase_add_test(tc_proto, test_udp_recvfrom_null_src_addr_len);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -176,6 +176,9 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_utils, test_wolfip_dns_server_get_returns_value_and_validates_args);
     tcase_add_test(tc_utils, test_wolfip_poll_executes_timers_and_callbacks);
     tcase_add_test(tc_utils, test_wolfip_poll_drains_all_expired_timers_in_one_pass);
+    tcase_add_test(tc_utils, test_wolfip_poll_tick_wrap_timer_due_after_wrap);
+    tcase_add_test(tc_utils, test_wolfip_poll_tick_wrap_timer_already_due_fires_now);
+    tcase_add_test(tc_utils, test_wolfip_poll_tick_wrap_mixed_timer_ordering);
     tcase_add_test(tc_utils, test_wolfip_poll_preserves_tcp_events_raised_during_callback);
     tcase_add_test(tc_utils, test_wolfip_poll_limits_device_drain_to_poll_budget);
     tcase_add_test(tc_utils, test_filter_notify_tcp_metadata);
@@ -254,6 +257,7 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_utils, test_sock_accept_negative_fd);
     tcase_add_test(tc_utils, test_sock_accept_invalid_tcp_fd);
     tcase_add_test(tc_utils, test_sock_accept_success_sets_addr);
+    tcase_add_test(tc_utils, test_sock_accept_listener_resets_paws_state);
     tcase_add_test(tc_utils, test_sock_accept_no_available_socket);
     tcase_add_test(tc_utils, test_sock_accept_no_free_socket_syn_rcvd);
     tcase_add_test(tc_utils, test_sock_accept_listen_no_connection);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1456,6 +1456,8 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_dhcp_parse_ack_rebind_time_len_lt4_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_ack_no_ip_after_ack_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_ack_no_mask_after_ack_rejected);
+    tcase_add_test(tc_core, test_dhcp_parse_ack_options_before_msg_type_accepted);
+    tcase_add_test(tc_core, test_dhcp_parse_ack_mismatched_server_id_before_msg_type_rejected);
     tcase_add_test(tc_core, test_dhcp_parse_ack_with_renewal_and_rebind_times);
     tcase_add_test(tc_core, test_dhcp_parse_ack_dns_already_set_skipped);
     tcase_add_test(tc_core, test_dhcp_parse_ack_inner_pad_bytes_skipped);

--- a/src/test/unit/unit_esp.c
+++ b/src/test/unit/unit_esp.c
@@ -2236,7 +2236,7 @@ static int     state_write_calls = 0;
 static uint32_t state_last_oseq = 0;
 
 static int state_test_read_cb(const uint8_t *spi, uint32_t *oseq,
-                              uint32_t *hi_seq, uint32_t *bitmap)
+                              uint32_t *hi_seq, uint64_t *bitmap)
 {
     state_read_calls++;
     if (memcmp(spi, state_test_spi, ESP_SPI_LEN) == 0) {
@@ -2248,7 +2248,7 @@ static int state_test_read_cb(const uint8_t *spi, uint32_t *oseq,
 }
 
 static int state_test_write_cb(const uint8_t *spi, uint32_t oseq,
-                               uint32_t hi_seq, uint32_t bitmap)
+                               uint32_t hi_seq, uint64_t bitmap)
 {
     state_write_calls++;
     if (memcmp(spi, state_test_spi, ESP_SPI_LEN) == 0) {
@@ -2273,7 +2273,7 @@ state_test_wire_seq(const struct wolfIP_ip_packet *ip)
 static uint8_t state_fail_spi[ESP_SPI_LEN] = {0x99, 0x88, 0x77, 0x66};
 
 static int state_fail_read_cb(const uint8_t *spi, uint32_t *oseq,
-                              uint32_t *hi_seq, uint32_t *bitmap)
+                              uint32_t *hi_seq, uint64_t *bitmap)
 {
     if (memcmp(spi, state_fail_spi, ESP_SPI_LEN) == 0) {
         *oseq   = 0xDEADBEEFU;
@@ -2316,6 +2316,99 @@ START_TEST(test_esp_state_restore_failed_read_keeps_fresh_state)
     wolfIP_esp_sa_del_all();
     ret = wolfIP_esp_state_set_cbs(NULL, NULL);
     ck_assert_int_eq(ret, 0);
+}
+END_TEST
+
+/* F-11440: the persistence callbacks must carry the full 64-bit replay
+ * bitmap. The old uint32_t callback types truncated bits 32..63 on save
+ * and reconstituted only the lower half on restore, so a duplicate in
+ * the upper half of the window was accepted after a restore. */
+static uint8_t  state_64bit_spi[ESP_SPI_LEN] = {0x55, 0x44, 0x33, 0x22};
+static uint32_t state64_oseq   = 0;
+static uint32_t state64_hi_seq = 0;
+static uint64_t state64_bitmap = 0;
+
+static int state64_read_cb(const uint8_t *spi, uint32_t *oseq,
+                           uint32_t *hi_seq, uint64_t *bitmap)
+{
+    if (memcmp(spi, state_64bit_spi, ESP_SPI_LEN) == 0) {
+        *oseq   = state64_oseq;
+        *hi_seq = state64_hi_seq;
+        *bitmap = state64_bitmap;
+        return 0;
+    }
+    return -1; /* unknown SPI: start fresh */
+}
+
+static int state64_write_cb(const uint8_t *spi, uint32_t oseq,
+                            uint32_t hi_seq, uint64_t bitmap)
+{
+    if (memcmp(spi, state_64bit_spi, ESP_SPI_LEN) == 0) {
+        state64_oseq   = oseq;
+        state64_hi_seq = hi_seq;
+        state64_bitmap = bitmap;
+    }
+    return 0;
+}
+
+START_TEST(test_esp_state_persistence_keeps_64bit_bitmap)
+{
+    int ret;
+    wolfIP_esp_sa *esp_sa;
+
+    esp_setup();
+    state64_oseq = 0;
+    state64_hi_seq = 0;
+    state64_bitmap = 0;
+
+    ret = wolfIP_esp_state_set_cbs(state64_write_cb, state64_read_cb);
+    ck_assert_int_eq(ret, 0);
+
+    ret = wolfIP_esp_sa_new_cbc_hmac(1, state_64bit_spi,
+                                     atoip4(T_SRC), atoip4(T_DST),
+                                     (uint8_t *)k_aes128, sizeof(k_aes128),
+                                     ESP_AUTH_SHA256_RFC4868,
+                                     (uint8_t *)k_auth16, sizeof(k_auth16),
+                                     ESP_ICVLEN_HMAC_128);
+    ck_assert_int_eq(ret, 0);
+    esp_sa = esp_sa_get(1, state_64bit_spi);
+    ck_assert_ptr_nonnull(esp_sa);
+
+    /* A window with a set bit in the upper half of the bitmap:
+     * hi_seq 100, seq 60 already accepted (bit 100-60 = 40). */
+    esp_sa->replay.oseq   = 7;
+    esp_sa->replay.hi_seq = 100;
+    esp_sa->replay.bitmap = (1ULL << 40) | 1ULL;
+
+    /* SA deletion is a save event: the write callback must receive the
+     * full 64-bit bitmap. */
+    wolfIP_esp_sa_del(1, state_64bit_spi);
+    ck_assert_uint_eq(state64_bitmap, (1ULL << 40) | 1ULL);
+    ck_assert_uint_eq(state64_hi_seq, 100U);
+    ck_assert_uint_eq(state64_oseq, 7U);
+
+    /* Recreating the SA must restore the full window, upper half
+     * included. */
+    ret = wolfIP_esp_sa_new_cbc_hmac(1, state_64bit_spi,
+                                     atoip4(T_SRC), atoip4(T_DST),
+                                     (uint8_t *)k_aes128, sizeof(k_aes128),
+                                     ESP_AUTH_SHA256_RFC4868,
+                                     (uint8_t *)k_auth16, sizeof(k_auth16),
+                                     ESP_ICVLEN_HMAC_128);
+    ck_assert_int_eq(ret, 0);
+    esp_sa = esp_sa_get(1, state_64bit_spi);
+    ck_assert_ptr_nonnull(esp_sa);
+    ck_assert_uint_eq(esp_sa->replay.bitmap, (1ULL << 40) | 1ULL);
+    ck_assert_uint_eq(esp_sa->replay.hi_seq, 100U);
+    ck_assert_uint_eq(esp_sa->replay.oseq, 7U);
+
+    /* The restored window must actually reject the upper-half duplicate
+     * (seq 60) and still accept new sequences. */
+    ck_assert_int_ne(esp_replay_check(&esp_sa->replay, 60U), 0);
+    ck_assert_int_eq(esp_replay_check(&esp_sa->replay, 101U), 0);
+
+    wolfIP_esp_sa_del_all();
+    wolfIP_esp_state_set_cbs(NULL, NULL);
 }
 END_TEST
 
@@ -2495,6 +2588,7 @@ static Suite *esp_suite(void)
     tcase_add_test(tc, test_sa_del_all);
     tcase_add_test(tc, test_esp_state_persistence_callbacks);
     tcase_add_test(tc, test_esp_state_restore_failed_read_keeps_fresh_state);
+    tcase_add_test(tc, test_esp_state_persistence_keeps_64bit_bitmap);
     suite_add_tcase(s, tc);
 
     /* Replay window */

--- a/src/test/unit/unit_tests_api.c
+++ b/src/test/unit/unit_tests_api.c
@@ -111,6 +111,120 @@ START_TEST(test_wolfip_poll_drains_all_expired_timers_in_one_pass)
 }
 END_TEST
 
+START_TEST(test_wolfip_poll_tick_wrap_timer_due_after_wrap)
+{
+    struct wolfIP s;
+    struct wolfIP_timer tmr;
+    uint64_t old_tick = 0xFFFFF000ULL; /* 4096 ticks before the 2^32 wrap */
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    timer_cb_calls = 0;
+
+    (void)wolfIP_poll(&s, old_tick);
+
+    /* Due 5000 ticks after the last poll: 904 ticks past the wrap point. */
+    memset(&tmr, 0, sizeof(tmr));
+    tmr.cb = test_timer_cb;
+    tmr.expires = old_tick + 5000;
+    (void)timers_binheap_insert(&s.timers, tmr);
+    ck_assert_uint_eq(s.timers.size, 1U);
+    ck_assert_uint_eq(s.timers.timers[0].expires, old_tick + 5000);
+    ck_assert_uint_eq(s.last_tick, old_tick);
+
+    /* The 32-bit source wraps: ... 0xFFFFF000 -> 0 -> ... -> 0x100.
+     * Without the rebase the deadline stays at 0x100000388 and the timer
+     * stalls for the rest of the counter period. */
+    (void)wolfIP_poll(&s, 0x100);
+    ck_assert_int_eq(timer_cb_calls, 0);
+
+    (void)wolfIP_poll(&s, 903);
+    ck_assert_int_eq(timer_cb_calls, 0);
+
+    (void)wolfIP_poll(&s, 904);
+    ck_assert_int_eq(timer_cb_calls, 1);
+    ck_assert_uint_eq(s.timers.size, 0U);
+}
+END_TEST
+
+START_TEST(test_wolfip_poll_tick_wrap_timer_already_due_fires_now)
+{
+    struct wolfIP s;
+    struct wolfIP_timer tmr;
+    uint64_t old_tick = 0xFFFFF000ULL;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    timer_cb_calls = 0;
+
+    (void)wolfIP_poll(&s, old_tick);
+
+    /* Due 3000 ticks after the last poll: 1096 ticks before the wrap
+     * point, so it is already overdue when the post-wrap poll arrives. */
+    memset(&tmr, 0, sizeof(tmr));
+    tmr.cb = test_timer_cb;
+    tmr.expires = old_tick + 3000;
+    (void)timers_binheap_insert(&s.timers, tmr);
+
+    (void)wolfIP_poll(&s, 0x100);
+
+    /* An overdue deadline must fire on the first poll of the new domain,
+     * not stall until the clock lapses the old absolute value. */
+    ck_assert_int_eq(timer_cb_calls, 1);
+    ck_assert_uint_eq(s.timers.size, 0U);
+}
+END_TEST
+
+START_TEST(test_wolfip_poll_tick_wrap_mixed_timer_ordering)
+{
+    struct wolfIP s;
+    struct wolfIP_timer tmr;
+    uint64_t old_tick = 0xFFFFF000ULL;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    timer_cb_calls = 0;
+
+    (void)wolfIP_poll(&s, old_tick);
+
+    /* Two old-domain deadlines: one due before the wrap (overdue at the
+     * post-wrap poll), one due 1404 ticks past it. */
+    memset(&tmr, 0, sizeof(tmr));
+    tmr.cb = test_timer_cb;
+    tmr.expires = old_tick + 3000;
+    (void)timers_binheap_insert(&s.timers, tmr);
+
+    memset(&tmr, 0, sizeof(tmr));
+    tmr.cb = test_timer_cb;
+    tmr.expires = old_tick + 5500;
+    (void)timers_binheap_insert(&s.timers, tmr);
+
+    /* Only the overdue one fires on the post-wrap poll; the other keeps
+     * its 1404-tick position in the new domain. */
+    (void)wolfIP_poll(&s, 0x100);
+    ck_assert_int_eq(timer_cb_calls, 1);
+
+    /* A timer armed in the new domain interleaves with the rebased one. */
+    memset(&tmr, 0, sizeof(tmr));
+    tmr.cb = test_timer_cb;
+    tmr.expires = s.last_tick + 100;
+    (void)timers_binheap_insert(&s.timers, tmr);
+
+    (void)wolfIP_poll(&s, 355);
+    ck_assert_int_eq(timer_cb_calls, 1);
+
+    (void)wolfIP_poll(&s, 356);
+    ck_assert_int_eq(timer_cb_calls, 2);
+
+    (void)wolfIP_poll(&s, 1403);
+    ck_assert_int_eq(timer_cb_calls, 2);
+
+    (void)wolfIP_poll(&s, 1404);
+    ck_assert_int_eq(timer_cb_calls, 3);
+    ck_assert_uint_eq(s.timers.size, 0U);
+}
+END_TEST
+
 START_TEST(test_wolfip_poll_preserves_tcp_events_raised_during_callback)
 {
     struct wolfIP s;
@@ -2368,6 +2482,126 @@ START_TEST(test_sock_accept_success_sets_addr)
     ck_assert_int_gt(client_sd, 0);
     ck_assert_uint_eq(alen, sizeof(sin));
     ck_assert_uint_eq(sin.sin_family, AF_INET);
+}
+END_TEST
+
+/* Inject a SYN carrying MSS + timestamp options from src_ip; ts_val is
+ * the peer timestamp that seeds the half-open listener's TS.Recent. */
+static void inject_tcp_syn_ts(struct wolfIP *s, unsigned int if_idx,
+        ip4 src_ip, ip4 dst_ip, uint16_t dst_port, uint32_t ts_val)
+{
+    uint8_t buf[sizeof(struct wolfIP_tcp_seg) +
+            sizeof(struct tcp_opt_mss) + sizeof(struct tcp_opt_ts)];
+    struct wolfIP_tcp_seg *syn = (struct wolfIP_tcp_seg *)buf;
+    struct wolfIP_ll_dev *ll = wolfIP_getdev_ex(s, if_idx);
+    union transport_pseudo_header ph;
+    struct tcp_opt_mss *mss;
+    struct tcp_opt_ts *tsopt;
+    static const uint8_t src_mac[6] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
+
+    ck_assert_ptr_nonnull(ll);
+    memset(buf, 0, sizeof(buf));
+    memcpy(syn->ip.eth.dst, ll->mac, 6);
+    memcpy(syn->ip.eth.src, src_mac, 6);
+    syn->ip.eth.type = ee16(ETH_TYPE_IP);
+    syn->ip.ver_ihl = 0x45;
+    syn->ip.ttl = 64;
+    syn->ip.proto = WI_IPPROTO_TCP;
+    syn->ip.len = ee16(IP_HEADER_LEN + TCP_HEADER_LEN +
+            (uint16_t)(sizeof(struct tcp_opt_mss) + sizeof(struct tcp_opt_ts)));
+    syn->ip.src = ee32(src_ip);
+    syn->ip.dst = ee32(dst_ip);
+    syn->ip.csum = 0;
+    iphdr_set_checksum(&syn->ip);
+
+    syn->src_port = ee16(40000);
+    syn->dst_port = ee16(dst_port);
+    syn->seq = ee32(1);
+    syn->ack = 0;
+    syn->hlen = (uint8_t)((TCP_HEADER_LEN + sizeof(struct tcp_opt_mss) +
+            sizeof(struct tcp_opt_ts)) / 4);
+    syn->flags = TCP_FLAG_SYN;
+    syn->win = ee16(65535);
+    syn->csum = 0;
+    syn->urg = 0;
+
+    mss = (struct tcp_opt_mss *)syn->data;
+    mss->opt = TCP_OPTION_MSS;
+    mss->len = TCP_OPTION_MSS_LEN;
+    mss->mss = ee16(1460);
+    tsopt = (struct tcp_opt_ts *)(syn->data + sizeof(struct tcp_opt_mss));
+    tsopt->opt = TCP_OPTION_TS;
+    tsopt->len = TCP_OPTION_TS_LEN;
+    tsopt->val = ee32(ts_val);
+    tsopt->ecr = 0;
+    tsopt->pad = TCP_OPTION_NOP;
+    tsopt->eoo = TCP_OPTION_NOP;
+
+    memset(&ph, 0, sizeof(ph));
+    ph.ph.src = syn->ip.src;
+    ph.ph.dst = syn->ip.dst;
+    ph.ph.proto = WI_IPPROTO_TCP;
+    ph.ph.len = ee16(TCP_HEADER_LEN + sizeof(struct tcp_opt_mss) +
+            sizeof(struct tcp_opt_ts));
+    syn->csum = ee16(transport_checksum(&ph, &syn->src_port));
+
+    tcp_input(s, if_idx, syn,
+            sizeof(struct wolfIP_eth_frame) + IP_HEADER_LEN + TCP_HEADER_LEN +
+            sizeof(struct tcp_opt_mss) + sizeof(struct tcp_opt_ts));
+}
+
+START_TEST(test_sock_accept_listener_resets_paws_state)
+{
+    struct wolfIP s;
+    int listen_sd;
+    struct tsocket *listener;
+    struct wolfIP_sockaddr_in sin;
+    socklen_t alen = sizeof(sin);
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+
+    listen_sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, WI_IPPROTO_TCP);
+    ck_assert_int_gt(listen_sd, 0);
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = ee16(1234);
+    sin.sin_addr.s_addr = ee32(0x0A000001U);
+    ck_assert_int_eq(wolfIP_sock_bind(&s, listen_sd, (struct wolfIP_sockaddr *)&sin, sizeof(sin)), 0);
+    ck_assert_int_eq(wolfIP_sock_listen(&s, listen_sd, 1), 0);
+
+    listener = &s.tcpsockets[SOCKET_UNMARK(listen_sd)];
+
+    /* Connection 1: the timestamped SYN seeds the half-open listener's
+     * TS.Recent (last_ts/ts_recent_valid) and enables PAWS. */
+    inject_tcp_syn_ts(&s, TEST_PRIMARY_IF, 0x0A0000A1U, 0x0A000001U, 1234,
+            0x10000000U);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
+    ck_assert_uint_eq(listener->sock.tcp.ts_enabled, 1);
+    ck_assert_uint_eq(listener->sock.tcp.last_ts, 0x10000000U);
+    ck_assert_uint_eq(listener->sock.tcp.ts_recent_valid, 1);
+
+    wolfIP_sock_accept(&s, listen_sd, (struct wolfIP_sockaddr *)&sin, &alen);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_LISTEN);
+
+    /* The reused listener must be back to a fresh baseline: the partial
+     * reset left connection 1's PAWS state (last_ts/ts_enabled/
+     * ts_recent_valid) on the port, so the next connection whose
+     * timestamps sit below the retained value inherits the stale
+     * TS.Recent and has its timestamped traffic dropped by PAWS. */
+    ck_assert_uint_eq(listener->sock.tcp.ts_enabled, 0);
+    ck_assert_uint_eq(listener->sock.tcp.ts_recent_valid, 0);
+    ck_assert_uint_eq(listener->sock.tcp.last_ts, 0U);
+
+    /* Connection 2, from a client with a lower timestamp epoch, must seed
+     * a fresh TS.Recent instead of inheriting connection 1's. */
+    inject_tcp_syn_ts(&s, TEST_PRIMARY_IF, 0x0A0000A2U, 0x0A000001U, 1234,
+            100U);
+    ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
+    ck_assert_uint_eq(listener->sock.tcp.ts_enabled, 1);
+    ck_assert_uint_eq(listener->sock.tcp.last_ts, 100U);
+    ck_assert_uint_eq(listener->sock.tcp.ts_recent_valid, 1);
 }
 END_TEST
 

--- a/src/test/unit/unit_tests_api.c
+++ b/src/test/unit/unit_tests_api.c
@@ -2518,8 +2518,10 @@ static void inject_tcp_syn_ts(struct wolfIP *s, unsigned int if_idx,
     syn->dst_port = ee16(dst_port);
     syn->seq = ee32(1);
     syn->ack = 0;
+    /* hlen stores the TCP header size in the 0xF0 encoding (bytes << 2),
+     * the same layout as the on-wire data-offset field. */
     syn->hlen = (uint8_t)((TCP_HEADER_LEN + sizeof(struct tcp_opt_mss) +
-            sizeof(struct tcp_opt_ts)) / 4);
+            sizeof(struct tcp_opt_ts)) << 2);
     syn->flags = TCP_FLAG_SYN;
     syn->win = ee16(65535);
     syn->csum = 0;
@@ -2579,7 +2581,9 @@ START_TEST(test_sock_accept_listener_resets_paws_state)
             0x10000000U);
     ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
     ck_assert_uint_eq(listener->sock.tcp.ts_enabled, 1);
-    ck_assert_uint_eq(listener->sock.tcp.last_ts, 0x10000000U);
+    /* last_ts is stored byte-swapped relative to the host timestamp value
+     * (the PAWS machinery recovers it with ee32; see the proto tests). */
+    ck_assert_uint_eq(listener->sock.tcp.last_ts, ee32(0x10000000U));
     ck_assert_uint_eq(listener->sock.tcp.ts_recent_valid, 1);
 
     wolfIP_sock_accept(&s, listen_sd, (struct wolfIP_sockaddr *)&sin, &alen);
@@ -2600,7 +2604,7 @@ START_TEST(test_sock_accept_listener_resets_paws_state)
             100U);
     ck_assert_int_eq(listener->sock.tcp.state, TCP_SYN_RCVD);
     ck_assert_uint_eq(listener->sock.tcp.ts_enabled, 1);
-    ck_assert_uint_eq(listener->sock.tcp.last_ts, 100U);
+    ck_assert_uint_eq(listener->sock.tcp.last_ts, ee32(100U));
     ck_assert_uint_eq(listener->sock.tcp.ts_recent_valid, 1);
 }
 END_TEST

--- a/src/test/unit/unit_tests_api.c
+++ b/src/test/unit/unit_tests_api.c
@@ -867,6 +867,54 @@ START_TEST(test_udp_sendto_and_recvfrom)
 }
 END_TEST
 
+START_TEST(test_udp_wildcard_bind_receives_all_local_addrs)
+{
+    struct wolfIP s;
+    int sd;
+    struct wolfIP_sockaddr_in sin;
+    struct wolfIP_sockaddr_in from;
+    socklen_t from_len = sizeof(from);
+    uint8_t payload[4] = {1, 2, 3, 4};
+    uint8_t rxbuf[LINK_MTU];
+    int ret;
+
+    setup_stack_with_two_ifaces(&s, 0x0A000001U, 0x0A010001U);
+
+    sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_DGRAM, WI_IPPROTO_UDP);
+    ck_assert_int_gt(sd, 0);
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = ee16(5353);
+    sin.sin_addr.s_addr = 0U; /* INADDR_ANY */
+    ck_assert_int_eq(wolfIP_sock_bind(&s, sd, (struct wolfIP_sockaddr *)&sin,
+            sizeof(sin)), 0);
+
+    /* A datagram addressed to the interface whose address was selected
+     * as the egress address at bind time is delivered. */
+    inject_udp_datagram(&s, TEST_PRIMARY_IF, 0x0A000064U, 0x0A000001U,
+            60000, 5353, payload, sizeof(payload));
+    memset(&from, 0, sizeof(from));
+    ret = wolfIP_sock_recvfrom(&s, sd, rxbuf, sizeof(rxbuf), 0,
+            (struct wolfIP_sockaddr *)&from, &from_len);
+    ck_assert_int_eq(ret, (int)sizeof(payload));
+    ck_assert_mem_eq(rxbuf, payload, sizeof(payload));
+
+    /* A datagram addressed to the other local address must be delivered
+     * too: a wildcard bind receives on every local address (POSIX). The
+     * pre-fix match compared only the egress address selected at bind
+     * time (local_ip), rejecting this datagram and replying
+     * port-unreachable. */
+    inject_udp_datagram(&s, TEST_SECOND_IF, 0x0A010064U, 0x0A010001U,
+            60001, 5353, payload, sizeof(payload));
+    memset(&from, 0, sizeof(from));
+    ret = wolfIP_sock_recvfrom(&s, sd, rxbuf, sizeof(rxbuf), 0,
+            (struct wolfIP_sockaddr *)&from, &from_len);
+    ck_assert_int_eq(ret, (int)sizeof(payload));
+    ck_assert_mem_eq(rxbuf, payload, sizeof(payload));
+    ck_assert_uint_eq(from.sin_port, ee16(60001));
+}
+END_TEST
+
 START_TEST(test_udp_sendto_respects_mtu_api)
 {
     struct wolfIP s;

--- a/src/test/unit/unit_tests_dhcp_edges.c
+++ b/src/test/unit/unit_tests_dhcp_edges.c
@@ -973,6 +973,95 @@ START_TEST(test_dhcp_parse_ack_no_mask_after_ack_rejected)
 }
 END_TEST
 
+/* F-11430: DHCP options are order-independent (RFC 2132). A valid
+ * DHCPACK carrying the server identifier, mask, router, and lease time
+ * before the message-type option must be accepted and committed. */
+START_TEST(test_dhcp_parse_ack_options_before_msg_type_accepted)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct ipconf *primary;
+    uint8_t *p;
+    uint32_t server_ip = 0x0A000001U;
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xEE66U;
+    s.last_tick = 0U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.dhcp_server_ip = server_ip;  /* committed during the OFFER phase */
+    primary = wolfIP_primary_ipconf(&s);
+    ck_assert_ptr_nonnull(primary);
+    primary->ip = client_ip;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.op = BOOT_REPLY;
+    msg.magic = ee32(DHCP_MAGIC);
+    msg.xid = ee32(s.dhcp_xid);
+    msg.yiaddr = ee32(client_ip);
+    p = (uint8_t *)msg.options;
+    /* Lease options before the message-type option. */
+    append_opt4(&p, DHCP_OPTION_SERVER_ID, server_ip);
+    append_opt4(&p, DHCP_OPTION_SUBNET_MASK, 0xFFFFFF00U);
+    append_opt4(&p, DHCP_OPTION_ROUTER, 0x0A000001U);
+    append_opt4(&p, DHCP_OPTION_LEASE_TIME, 3600U);
+    p[0] = DHCP_OPTION_MSG_TYPE; p[1] = 1; p[2] = DHCP_ACK; p += 3;
+    append_end(&p);
+
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), 0);
+    ck_assert_uint_eq(s.dhcp_server_ip, server_ip);
+    ck_assert_uint_eq(primary->ip, client_ip);
+    ck_assert_uint_eq(primary->mask, 0xFFFFFF00U);
+    ck_assert_uint_eq(primary->gw, 0x0A000001U);
+}
+END_TEST
+
+/* A server identifier that does not match the server committed during
+ * the OFFER phase is rejected wherever it appears in the stream: the
+ * ordering gate must not let a mismatched server-id before option 53
+ * slide past the check. */
+START_TEST(test_dhcp_parse_ack_mismatched_server_id_before_msg_type_rejected)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct ipconf *primary;
+    uint8_t *p;
+    uint32_t server_ip = 0x0A000001U;   /* committed during the OFFER phase */
+    uint32_t client_ip = 0x0A000064U;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    s.dhcp_xid = 0xEE77U;
+    s.last_tick = 0U;
+    s.dhcp_state = DHCP_REQUEST_SENT;
+    s.dhcp_server_ip = server_ip;
+    primary = wolfIP_primary_ipconf(&s);
+    ck_assert_ptr_nonnull(primary);
+    primary->ip = client_ip;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.op = BOOT_REPLY;
+    msg.magic = ee32(DHCP_MAGIC);
+    msg.xid = ee32(s.dhcp_xid);
+    msg.yiaddr = ee32(client_ip);
+    p = (uint8_t *)msg.options;
+    /* Mismatched server id before the message-type option, then a fully
+     * valid ACK (matching server id + all mandatory fields). */
+    append_opt4(&p, DHCP_OPTION_SERVER_ID, 0x0A000099U);
+    p[0] = DHCP_OPTION_MSG_TYPE; p[1] = 1; p[2] = DHCP_ACK; p += 3;
+    append_opt4(&p, DHCP_OPTION_SERVER_ID, server_ip);
+    append_opt4(&p, DHCP_OPTION_SUBNET_MASK, 0xFFFFFF00U);
+    append_opt4(&p, DHCP_OPTION_ROUTER, 0x0A000001U);
+    append_opt4(&p, DHCP_OPTION_LEASE_TIME, 3600U);
+    append_end(&p);
+
+    ck_assert_int_eq(dhcp_parse_ack(&s, &msg, sizeof(msg)), -1);
+    /* Nothing committed: the interface keeps its pre-ACK configuration. */
+    ck_assert_uint_eq(s.dhcp_state, DHCP_REQUEST_SENT);
+}
+END_TEST
+
 START_TEST(test_dhcp_parse_ack_with_renewal_and_rebind_times)
 {
     /* Happy path: ACK with T1 (renewal) and T2 (rebind) options set. */

--- a/src/test/unit/unit_tests_dhcp_edges.c
+++ b/src/test/unit/unit_tests_dhcp_edges.c
@@ -505,6 +505,70 @@ START_TEST(test_dhcp_parse_offer_subnet_mask_len_lt4_rejected)
 }
 END_TEST
 
+/* F-11429: DHCP options are order-independent (RFC 2132). A valid
+ * DHCPOFFER that places the server identifier and subnet mask before the
+ * message-type option must be accepted, not rejected. */
+START_TEST(test_dhcp_parse_offer_options_before_msg_type_accepted)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    uint8_t *p;
+
+    wolfIP_init(&s);
+    s.dhcp_xid = 0x4004U;
+    s.dhcp_state = DHCP_DISCOVER_SENT;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.op = BOOT_REPLY;
+    msg.magic = ee32(DHCP_MAGIC);
+    msg.xid = ee32(s.dhcp_xid);
+    msg.yiaddr = ee32(0x0A000064U);
+    p = (uint8_t *)msg.options;
+    /* Required options before the message-type option. */
+    p[0] = DHCP_OPTION_SERVER_ID; p[1] = 4;
+    p[2] = 10; p[3] = 0; p[4] = 0; p[5] = 1;
+    p += 6;
+    p[0] = DHCP_OPTION_SUBNET_MASK; p[1] = 4;
+    p[2] = 0xFF; p[3] = 0xFF; p[4] = 0xFF; p[5] = 0x00;
+    p += 6;
+    p[0] = DHCP_OPTION_MSG_TYPE; p[1] = 1; p[2] = DHCP_OFFER; p += 3;
+    p[0] = DHCP_OPTION_END;
+
+    ck_assert_int_eq(dhcp_parse_offer(&s, &msg, sizeof(msg)), 0);
+    ck_assert_uint_eq(s.dhcp_server_ip, 0x0A000001U);
+    ck_assert_uint_eq(s.dhcp_ip, 0x0A000064U);
+    ck_assert_uint_eq(s.dhcp_offered_mask, 0xFFFFFF00U);
+    ck_assert_uint_eq(s.dhcp_state, DHCP_REQUEST_SENT);
+}
+END_TEST
+
+/* A truncated server identifier is rejected wherever it appears in the
+ * option stream, including before the message-type option. */
+START_TEST(test_dhcp_parse_offer_bad_server_id_before_msg_type_rejected)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    uint8_t *p;
+
+    wolfIP_init(&s);
+    s.dhcp_xid = 0x4005U;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.op = BOOT_REPLY;
+    msg.magic = ee32(DHCP_MAGIC);
+    msg.xid = ee32(s.dhcp_xid);
+    msg.yiaddr = ee32(0x0A000064U);
+    p = (uint8_t *)msg.options;
+    /* SERVER_ID with len=2 < 4, before the message-type option. */
+    p[0] = DHCP_OPTION_SERVER_ID; p[1] = 2; p[2] = 10; p[3] = 0;
+    p += 4;
+    p[0] = DHCP_OPTION_MSG_TYPE; p[1] = 1; p[2] = DHCP_OFFER; p += 3;
+    p[0] = DHCP_OPTION_END;
+
+    ck_assert_int_eq(dhcp_parse_offer(&s, &msg, sizeof(msg)), -1);
+}
+END_TEST
+
 START_TEST(test_dhcp_parse_offer_inner_truncated_opt2_rejected)
 {
     struct wolfIP s;
@@ -590,17 +654,20 @@ START_TEST(test_dhcp_parse_offer_inner_pad_then_end)
 }
 END_TEST
 
-START_TEST(test_dhcp_parse_offer_outer_end_with_state_already_set)
+START_TEST(test_dhcp_parse_offer_non_offer_with_stale_state_rejected)
 {
-    /* Covers the branch at line ~7487:
-     * saw_end=1 after outer END, dhcp_server_ip != 0 && dhcp_ip != 0 → 0 */
+    /* A non-OFFER reply must be rejected outright, even if stale offer
+     * state is present: re-arming REQUEST_SENT from a stale offer in
+     * response to an ACK/NAK-type message would request a lease this
+     * round's OFFER never granted. */
     struct wolfIP s;
     struct dhcp_msg msg;
     uint8_t *p;
 
     wolfIP_init(&s);
     s.dhcp_xid = 0x5005U;
-    /* Pre-set as if an OFFER was already processed */
+    s.dhcp_state = DHCP_DISCOVER_SENT;
+    /* Pre-set as if an OFFER from an earlier round was processed. */
     s.dhcp_server_ip = 0x0A000001U;
     s.dhcp_ip = 0x0A000064U;
 
@@ -609,13 +676,12 @@ START_TEST(test_dhcp_parse_offer_outer_end_with_state_already_set)
     msg.magic = ee32(DHCP_MAGIC);
     msg.xid = ee32(s.dhcp_xid);
     p = (uint8_t *)msg.options;
-    /* MSG_TYPE = ACK (not OFFER) so inner body not entered; outer loop sees END */
+    /* MSG_TYPE = ACK (not OFFER). */
     p[0] = DHCP_OPTION_MSG_TYPE; p[1] = 1; p[2] = DHCP_ACK; p += 3;
     p[0] = DHCP_OPTION_END;
 
-    /* outer saw_end=1, server_ip != 0, dhcp_ip != 0 → returns 0 */
-    ck_assert_int_eq(dhcp_parse_offer(&s, &msg, sizeof(msg)), 0);
-    ck_assert_int_eq(s.dhcp_state, DHCP_REQUEST_SENT);
+    ck_assert_int_eq(dhcp_parse_offer(&s, &msg, sizeof(msg)), -1);
+    ck_assert_uint_eq(s.dhcp_state, DHCP_DISCOVER_SENT);
 }
 END_TEST
 

--- a/src/test/unit/unit_tests_dns_dhcp.c
+++ b/src/test/unit/unit_tests_dns_dhcp.c
@@ -3507,8 +3507,8 @@ START_TEST(test_dhcp_parse_offer_option_overload)
     s.dhcp_xid = 0x1234;
 
     /* --- Scenario 1: overload = sname (value 2) ---
-     * Options field: OFFER, mask, overload; no END — the stream
-     * continues into the sname field, which holds the server id. */
+     * Options field: OFFER, mask, overload, END; the server id is held
+     * in the sname field, a separate option list (RFC 2132 sec.9.3). */
     memset(&msg, 0, sizeof(msg));
     msg.op = BOOT_REPLY;
     msg.magic = ee32(DHCP_MAGIC);
@@ -3522,6 +3522,7 @@ START_TEST(test_dhcp_parse_offer_option_overload)
     opt += 6;
     opt[0] = 52 /* DHCP_OPTION_OVERLOAD */; opt[1] = 1; opt[2] = 2;
     opt += 3;
+    *opt++ = DHCP_OPTION_END;
     opt_len = (uint32_t)(opt - (uint8_t *)msg.options);
     field_opt = (struct dhcp_option *)msg.sname;
     field_opt->code = DHCP_OPTION_SERVER_ID;
@@ -3555,6 +3556,7 @@ START_TEST(test_dhcp_parse_offer_option_overload)
     opt += 3;
     opt[0] = 52 /* DHCP_OPTION_OVERLOAD */; opt[1] = 1; opt[2] = 1;
     opt += 3;
+    *opt++ = DHCP_OPTION_END;
     opt_len = (uint32_t)(opt - (uint8_t *)msg.options);
     field_opt = (struct dhcp_option *)msg.file;
     field_opt->code = DHCP_OPTION_SERVER_ID;
@@ -3569,9 +3571,9 @@ START_TEST(test_dhcp_parse_offer_option_overload)
     ck_assert_int_eq(ret, 0);
     ck_assert_uint_eq(s.dhcp_server_ip, 0x0A000064U);
 
-    /* --- Scenario 3: overload = both (value 3): the stream runs
-     * options -> sname -> file; the mask is in sname, the server id in
-     * file. */
+    /* --- Scenario 3: overload = both (value 3): the option lists run
+     * options (terminated by END) -> sname -> file; the mask is in
+     * sname, the server id in file. */
     memset(&s, 0, sizeof(s));
     wolfIP_init(&s);
     mock_link_init(&s);
@@ -3587,6 +3589,7 @@ START_TEST(test_dhcp_parse_offer_option_overload)
     opt += 3;
     opt[0] = 52 /* DHCP_OPTION_OVERLOAD */; opt[1] = 1; opt[2] = 3;
     opt += 3;
+    *opt++ = DHCP_OPTION_END;
     opt_len = (uint32_t)(opt - (uint8_t *)msg.options);
     field_opt = (struct dhcp_option *)msg.sname;
     field_opt->code = DHCP_OPTION_SUBNET_MASK;
@@ -3716,6 +3719,97 @@ START_TEST(test_dhcp_parse_offer_option_split_across_region_boundary_rejected)
     ret = dhcp_parse_offer(&s, &msg, DHCP_HEADER_LEN + opt_len);
     ck_assert_int_eq(ret, -1);
     ck_assert_uint_eq(s.dhcp_server_ip, 0U);
+}
+END_TEST
+
+/* F-11442: the main options field must be terminated by the end option
+ * (RFC 2132 sec.3.2). An end option found later in an overloaded field
+ * must not satisfy the main field's terminator: a main field that runs
+ * out before its end option is malformed and must be rejected in strict
+ * parsing, even if the remaining fields are well formed. */
+START_TEST(test_dhcp_parse_offer_main_field_without_end_rejected)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    uint8_t *opt;
+    uint8_t *sn;
+    uint32_t opt_len;
+    int ret;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    s.dhcp_xid = 0x1234;
+    memset(&msg, 0, sizeof(msg));
+    msg.op = BOOT_REPLY;
+    msg.magic = ee32(DHCP_MAGIC);
+    msg.xid = ee32(s.dhcp_xid);
+    msg.yiaddr = ee32(0x0A00000AU);
+    opt = (uint8_t *)msg.options;
+    opt[0] = DHCP_OPTION_MSG_TYPE; opt[1] = 1; opt[2] = DHCP_OFFER;
+    opt += 3;
+    opt[0] = 52 /* DHCP_OPTION_OVERLOAD */; opt[1] = 1; opt[2] = 2;
+    opt += 3;
+    opt[0] = DHCP_OPTION_SERVER_ID; opt[1] = 4;
+    opt[2] = 0x0A; opt[3] = 0x00; opt[4] = 0x00; opt[5] = 0x64;
+    opt += 6;
+    /* No END in the main options field. */
+    opt_len = (uint32_t)(opt - (uint8_t *)msg.options);
+    sn = (uint8_t *)msg.sname;
+    sn[0] = DHCP_OPTION_END; /* the only END, in the overloaded field */
+
+    ret = dhcp_parse_offer(&s, &msg, DHCP_HEADER_LEN + opt_len);
+    ck_assert_int_eq(ret, -1);
+}
+END_TEST
+
+/* F-11442: a conforming overloaded OFFER - main field terminated by
+ * its end option, the server id in the sname field's own option list -
+ * must be accepted: after the main field's end option the stream
+ * continues into the overloaded fields and the final field's end
+ * option terminates it. */
+START_TEST(test_dhcp_parse_offer_compliant_overloaded_offer_accepted)
+{
+    struct wolfIP s;
+    struct dhcp_msg msg;
+    struct dhcp_option *field_opt;
+    uint8_t *opt;
+    uint32_t opt_len;
+    int ret;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
+    s.dhcp_xid = 0x1234;
+    memset(&msg, 0, sizeof(msg));
+    msg.op = BOOT_REPLY;
+    msg.magic = ee32(DHCP_MAGIC);
+    msg.xid = ee32(s.dhcp_xid);
+    msg.yiaddr = ee32(0x0A00000AU);
+    opt = (uint8_t *)msg.options;
+    opt[0] = DHCP_OPTION_MSG_TYPE; opt[1] = 1; opt[2] = DHCP_OFFER;
+    opt += 3;
+    opt[0] = DHCP_OPTION_SUBNET_MASK; opt[1] = 4;
+    opt[2] = 0xFF; opt[3] = 0xFF; opt[4] = 0xFF; opt[5] = 0x00;
+    opt += 6;
+    opt[0] = 52 /* DHCP_OPTION_OVERLOAD */; opt[1] = 1; opt[2] = 2;
+    opt += 3;
+    *opt++ = DHCP_OPTION_END; /* main field properly terminated */
+    opt_len = (uint32_t)(opt - (uint8_t *)msg.options);
+    field_opt = (struct dhcp_option *)msg.sname;
+    field_opt->code = DHCP_OPTION_SERVER_ID;
+    field_opt->len = 4;
+    field_opt->data[0] = 0x0A; field_opt->data[1] = 0x00;
+    field_opt->data[2] = 0x00; field_opt->data[3] = 0x64;
+    field_opt = (struct dhcp_option *)((uint8_t *)field_opt + 6);
+    field_opt->code = DHCP_OPTION_END;
+    field_opt->len = 0;
+
+    ret = dhcp_parse_offer(&s, &msg, DHCP_HEADER_LEN + opt_len);
+    ck_assert_int_eq(ret, 0);
+    ck_assert_uint_eq(s.dhcp_server_ip, 0x0A000064U);
+    ck_assert_uint_eq(s.dhcp_ip, 0x0A00000AU);
+    ck_assert_int_eq(s.dhcp_state, DHCP_REQUEST_SENT);
 }
 END_TEST
 START_TEST(test_fifo_push_and_pop) {

--- a/src/test/unit/unit_tests_dns_dhcp.c
+++ b/src/test/unit/unit_tests_dns_dhcp.c
@@ -3612,11 +3612,17 @@ START_TEST(test_dhcp_parse_offer_option_overload)
 }
 END_TEST
 
-/* An option split across a region boundary is a continuation of the
- * option stream (RFC 2132 §9.3), not the start of a new option list:
- * the server id must be parsed across the split in each boundary
- * shape. */
-START_TEST(test_dhcp_parse_offer_option_split_across_region_boundary)
+/* F-11441: an option whose header or data crosses a field boundary is
+ * malformed, not a continuation of the option stream. RFC 2132
+ * sec.3.2 makes the end option the terminator of each field's valid
+ * information and sec.9.3 has the client interpret the overloaded
+ * fields only after concluding interpretation of the standard option
+ * fields - each field is a separate option list. Strict parsing must
+ * reject the split in each boundary shape; nothing may be committed.
+ * (The earlier reading that treated the fields as one continuous byte
+ * stream misread sec.9.3 and let a hostile server assemble arbitrary
+ * option bytes out of the field boundary.) */
+START_TEST(test_dhcp_parse_offer_option_split_across_region_boundary_rejected)
 {
     struct wolfIP s;
     struct dhcp_msg msg;
@@ -3627,7 +3633,7 @@ START_TEST(test_dhcp_parse_offer_option_split_across_region_boundary)
     int ret;
 
     /* --- Scenario 1: the server id's code byte is the last byte of
-     * the options field; its length, data and END continue in sname. --- */
+     * the options field; its length and data continue in sname. --- */
     wolfIP_init(&s);
     mock_link_init(&s);
     wolfIP_ipconfig_set(&s, 0x0A000001U, 0xFFFFFF00U, 0);
@@ -3650,10 +3656,8 @@ START_TEST(test_dhcp_parse_offer_option_split_across_region_boundary)
     sn[5] = DHCP_OPTION_END;
 
     ret = dhcp_parse_offer(&s, &msg, DHCP_HEADER_LEN + opt_len);
-    ck_assert_int_eq(ret, 0);
-    ck_assert_uint_eq(s.dhcp_server_ip, 0x0A000064U);
-    ck_assert_uint_eq(s.dhcp_ip, 0x0A00000AU);
-    ck_assert_int_eq(s.dhcp_state, DHCP_REQUEST_SENT);
+    ck_assert_int_eq(ret, -1);
+    ck_assert_uint_eq(s.dhcp_server_ip, 0U);
 
     /* --- Scenario 2: code + length are the last two bytes of the
      * options field; the four data bytes split 2 + 2 into sname. --- */
@@ -3681,8 +3685,8 @@ START_TEST(test_dhcp_parse_offer_option_split_across_region_boundary)
     sn[4] = DHCP_OPTION_END;
 
     ret = dhcp_parse_offer(&s, &msg, DHCP_HEADER_LEN + opt_len);
-    ck_assert_int_eq(ret, 0);
-    ck_assert_uint_eq(s.dhcp_server_ip, 0x0A000064U);
+    ck_assert_int_eq(ret, -1);
+    ck_assert_uint_eq(s.dhcp_server_ip, 0U);
 
     /* --- Scenario 3: overload = both; the server id starts at the
      * end of sname (pads precede it) and its data runs into file. --- */
@@ -3710,8 +3714,8 @@ START_TEST(test_dhcp_parse_offer_option_split_across_region_boundary)
     fl[2] = DHCP_OPTION_END;
 
     ret = dhcp_parse_offer(&s, &msg, DHCP_HEADER_LEN + opt_len);
-    ck_assert_int_eq(ret, 0);
-    ck_assert_uint_eq(s.dhcp_server_ip, 0x0A000064U);
+    ck_assert_int_eq(ret, -1);
+    ck_assert_uint_eq(s.dhcp_server_ip, 0U);
 }
 END_TEST
 START_TEST(test_fifo_push_and_pop) {

--- a/src/test/unit/unit_tests_ip_arp_recv.c
+++ b/src/test/unit/unit_tests_ip_arp_recv.c
@@ -661,6 +661,176 @@ START_TEST(test_ip_recv_l2_broadcast_frame_not_forwarded)
 END_TEST
 
 /* =========================================================================
+ * F-11438: a non-local datagram that is not forwarded must not fall
+ * through to local protocol dispatch.
+ * =========================================================================
+ * The UDP RECEIVING filter notification fires inside udp_try_recv, before
+ * socket matching, so it observes whether a datagram reached local
+ * dispatch at all.
+ */
+static int f11438_udp_rx_seen;
+
+static int f11438_filter_cb(void *arg, const struct wolfIP_filter_event *ev)
+{
+    (void)arg;
+    if (ev->reason == WOLFIP_FILT_RECEIVING &&
+            ev->meta.ip_proto == WOLFIP_FILTER_PROTO_UDP)
+        f11438_udp_rx_seen++;
+    return 0; /* allow */
+}
+
+static void f11438_install_rx_observer(void)
+{
+    f11438_udp_rx_seen = 0;
+    wolfIP_filter_set_callback(f11438_filter_cb, NULL);
+    wolfIP_filter_set_udp_mask(WOLFIP_FILT_MASK(WOLFIP_FILT_RECEIVING));
+}
+
+static void f11438_uninstall_rx_observer(void)
+{
+    wolfIP_filter_set_callback(NULL, NULL);
+}
+
+/* Unicast L2 frame, non-local destination, no connected or static route:
+ * the router must drop it (RFC 1122 sec.4.2.2.9), not hand it to its own
+ * UDP/TCP/ICMP handlers. (The ICMP Network Unreachable reply is a separate
+ * concern — F-1332, wont_fix — and is intentionally not asserted here.) */
+START_TEST(test_ip_recv_forward_no_route_dropped_not_dispatched)
+{
+    struct wolfIP s;
+    uint8_t frame[ETH_HEADER_LEN + IP_HEADER_LEN + UDP_HEADER_LEN];
+    struct wolfIP_ip_packet *ip = (struct wolfIP_ip_packet *)frame;
+    ip4 primary_ip   = 0x0A000001U;
+    ip4 secondary_ip = 0xC0A80101U;
+    ip4 src_ip       = 0x0A000002U;   /* 10.0.0.2 passes every RPF check */
+    ip4 dest_ip      = 0xAC100505U;   /* 172.16.5.5 — non-local, no route */
+
+    setup_stack_with_two_ifaces(&s, primary_ip, secondary_ip);
+    f11438_install_rx_observer();
+
+    memset(frame, 0, sizeof(frame));
+    memcpy(ip->eth.dst, s.ll_dev[TEST_PRIMARY_IF].mac, 6);
+    memcpy(ip->eth.src, "\x01\x02\x03\x04\x05\x06", 6);
+    ip->eth.type = ee16(ETH_TYPE_IP);
+    ip->ver_ihl  = 0x45;
+    ip->ttl      = 64;
+    ip->proto    = WI_IPPROTO_UDP;
+    ip->len      = ee16(IP_HEADER_LEN + UDP_HEADER_LEN);
+    ip->src      = ee32(src_ip);
+    ip->dst      = ee32(dest_ip);
+    fix_ip_checksum(ip);
+    {
+        uint16_t *udp = (uint16_t *)(frame + ETH_HEADER_LEN + IP_HEADER_LEN);
+        udp[0] = ee16(9999); udp[1] = ee16(1234);
+        udp[2] = ee16(UDP_HEADER_LEN); udp[3] = 0;
+    }
+
+    last_frame_sent_size = 0;
+    ip_recv(&s, TEST_PRIMARY_IF, ip, (uint32_t)sizeof(frame));
+
+    /* Nothing forwarded, nothing queued behind an ARP resolution... */
+    ck_assert_uint_eq(last_frame_sent_size, 0);
+    ck_assert_uint_eq(s.arp_pending[0].dest, IPADDR_ANY);
+    /* ...and the datagram never reaches local UDP dispatch. */
+    ck_assert_int_eq(f11438_udp_rx_seen, 0);
+
+    f11438_uninstall_rx_observer();
+}
+END_TEST
+
+/* L2-broadcast frame carrying a unicast ip.dst that is not locally
+ * deliverable (not IGMP, not 224/4 multicast, not DHCP 67->68): RFC 1812
+ * sec.5.3.4 forbids forwarding it, and it is not addressed to this node,
+ * so it must be discarded — not passed to local protocol dispatch. */
+START_TEST(test_ip_recv_l2_group_not_locally_deliverable_dropped)
+{
+    struct wolfIP s;
+    uint8_t frame[ETH_HEADER_LEN + IP_HEADER_LEN + UDP_HEADER_LEN];
+    struct wolfIP_ip_packet *ip = (struct wolfIP_ip_packet *)frame;
+    ip4 primary_ip   = 0x0A000001U;
+    ip4 secondary_ip = 0xC0A80101U;
+    ip4 src_ip       = 0x0A000002U;   /* 10.0.0.2 passes every RPF check */
+    ip4 dest_ip      = 0xAC100505U;   /* 172.16.5.5 — non-local unicast */
+
+    setup_stack_with_two_ifaces(&s, primary_ip, secondary_ip);
+    f11438_install_rx_observer();
+
+    memset(frame, 0, sizeof(frame));
+    memcpy(ip->eth.dst, "\xff\xff\xff\xff\xff\xff", 6);
+    memcpy(ip->eth.src, "\x01\x02\x03\x04\x05\x06", 6);
+    ip->eth.type = ee16(ETH_TYPE_IP);
+    ip->ver_ihl  = 0x45;
+    ip->ttl      = 64;
+    ip->proto    = WI_IPPROTO_UDP;
+    ip->len      = ee16(IP_HEADER_LEN + UDP_HEADER_LEN);
+    ip->src      = ee32(src_ip);
+    ip->dst      = ee32(dest_ip);
+    fix_ip_checksum(ip);
+    {
+        uint16_t *udp = (uint16_t *)(frame + ETH_HEADER_LEN + IP_HEADER_LEN);
+        udp[0] = ee16(9999); udp[1] = ee16(1234);
+        udp[2] = ee16(UDP_HEADER_LEN); udp[3] = 0;
+    }
+
+    last_frame_sent_size = 0;
+    wolfIP_recv_on(&s, TEST_PRIMARY_IF, frame, (uint32_t)sizeof(frame));
+
+    /* Not forwarded (RFC 1812 sec.5.3.4), not queued, not dispatched. */
+    ck_assert_uint_eq(last_frame_sent_size, 0);
+    ck_assert_uint_eq(s.arp_pending[0].dest, IPADDR_ANY);
+    ck_assert_int_eq(f11438_udp_rx_seen, 0);
+
+    f11438_uninstall_rx_observer();
+}
+END_TEST
+
+/* Guard: the L2-group fall-through exists to deliver DHCPOFFER/ACK, which
+ * arrive L2-broadcast carrying an ip.dst the client does not own yet
+ * (RFC 2131). A UDP 67->68 broadcast datagram must still reach local UDP
+ * dispatch after the F-11438 drop is in place. */
+START_TEST(test_ip_recv_l2_group_dhcp_still_reaches_local_udp)
+{
+    struct wolfIP s;
+    uint8_t frame[ETH_HEADER_LEN + IP_HEADER_LEN + UDP_HEADER_LEN];
+    struct wolfIP_ip_packet *ip = (struct wolfIP_ip_packet *)frame;
+    ip4 primary_ip   = 0x0A000001U;
+    ip4 secondary_ip = 0xC0A80101U;
+    ip4 src_ip       = 0x0A000002U;
+    ip4 dest_ip      = 0x0A000063U;   /* 10.0.0.99 — not yet ours */
+
+    setup_stack_with_two_ifaces(&s, primary_ip, secondary_ip);
+    f11438_install_rx_observer();
+
+    memset(frame, 0, sizeof(frame));
+    memcpy(ip->eth.dst, "\xff\xff\xff\xff\xff\xff", 6);
+    memcpy(ip->eth.src, "\x01\x02\x03\x04\x05\x06", 6);
+    ip->eth.type = ee16(ETH_TYPE_IP);
+    ip->ver_ihl  = 0x45;
+    ip->ttl      = 64;
+    ip->proto    = WI_IPPROTO_UDP;
+    ip->len      = ee16(IP_HEADER_LEN + UDP_HEADER_LEN);
+    ip->src      = ee32(src_ip);
+    ip->dst      = ee32(dest_ip);
+    fix_ip_checksum(ip);
+    {
+        uint16_t *udp = (uint16_t *)(frame + ETH_HEADER_LEN + IP_HEADER_LEN);
+        udp[0] = ee16(67); udp[1] = ee16(68);   /* DHCP server -> client */
+        udp[2] = ee16(UDP_HEADER_LEN); udp[3] = 0;
+    }
+
+    last_frame_sent_size = 0;
+    wolfIP_recv_on(&s, TEST_PRIMARY_IF, frame, (uint32_t)sizeof(frame));
+
+    /* Never forwarded... */
+    ck_assert_uint_eq(last_frame_sent_size, 0);
+    /* ...but still dispatched to local UDP (the DHCP socket path). */
+    ck_assert_int_eq(f11438_udp_rx_seen, 1);
+
+    f11438_uninstall_rx_observer();
+}
+END_TEST
+
+/* =========================================================================
  * ip_recv: IP with NOP options — options parsed, payload delivered
  * =========================================================================
  * Branch: type == 1 (NOP) inside option parser → opt++ continue

--- a/src/wolfesp.c
+++ b/src/wolfesp.c
@@ -61,7 +61,7 @@ esp_state_restore(wolfIP_esp_sa *sa)
 {
     uint32_t oseq;
     uint32_t hi_seq;
-    uint32_t bitmap;
+    uint64_t bitmap;
 
     if (esp_state_read_cb) {
         oseq   = sa->replay.oseq;

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8961,6 +8961,7 @@ static int dhcp_parse_ack(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_l
     struct dhcp_opt_stream st;
     int saw_end = 0;
     int saw_server_id = 0;
+    int msg_type = 0;
     struct ipconf *primary = wolfIP_primary_ipconf(s);
     uint32_t lease_ip = 0;
     uint32_t lease_mask = 0;
@@ -8987,6 +8988,9 @@ static int dhcp_parse_ack(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_l
         return -1;
     if (ee32(msg->xid) != s->dhcp_xid)
         return -1;
+    /* RFC 2132: options are order-independent. Collect the fields in one
+     * pass regardless of order and validate the message type and the
+     * mandatory lease fields at the end of the stream. */
     dhcp_opt_stream_init(&st, msg, msg_len, 1);
     while (1) {
         uint8_t code;
@@ -9004,126 +9008,121 @@ static int dhcp_parse_ack(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg_l
         if (code == DHCP_OPTION_MSG_TYPE) {
             if (len != 1)
                 return -1;
-            if (data[2] == DHCP_ACK) {
-                while (1) {
-                    uint8_t *idata;
-                    uint32_t val;
-                    r = dhcp_opt_stream_next(&st, &code, &len, &idata);
-                    if (r < 0)
-                        return -1;
-                    if (r == 0)
-                        break;
-                    if (code == DHCP_OPTION_END) {
-                        saw_end = 1;
-                        break;
-                    }
-                    if (code == DHCP_OPTION_SERVER_ID) {
-                        if (len < 4)
-                            return -1;
-                        val = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                        /* Reject ACK from a server other than the one
-                         * we committed to during the OFFER phase. */
-                        if (s->dhcp_server_ip != 0 && val != s->dhcp_server_ip)
-                            return -1;
-                        cand_server_ip = val;
-                        saw_server_id = 1;
-                    } else if (code == DHCP_OPTION_OFFER_IP) {
-                        if (len < 4)
-                            return -1;
-                        cand_ip = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                        have_ip = 1;
-                    } else if (primary && code == DHCP_OPTION_SUBNET_MASK) {
-                        if (len < 4)
-                            return -1;
-                        cand_mask = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                        have_mask = 1;
-                    } else if (primary && code == DHCP_OPTION_ROUTER) {
-                        if (len < 4)
-                            return -1;
-                        cand_gw = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                        have_gw = 1;
-                    } else if ((code == DHCP_OPTION_DNS) && (s->dns_server == 0)) {
-                        if (len < 4)
-                            return -1;
-                        if (cand_dns == 0)
-                            cand_dns = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                    } else if (code == DHCP_OPTION_LEASE_TIME) {
-                        if (len < 4)
-                            return -1;
-                        lease_s = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                    } else if (code == DHCP_OPTION_RENEWAL_TIME) {
-                        if (len < 4)
-                            return -1;
-                        renew_s = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                    } else if (code == DHCP_OPTION_REBIND_TIME) {
-                        if (len < 4)
-                            return -1;
-                        rebind_s = DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                    }
-                }
-                if (!saw_end)
-                    return -1;
-                /* The lease address is option 50 (the requested IP) when the
-                 * server echoes it, otherwise the yiaddr it committed; either
-                 * way it must be a usable unicast address before it is applied
-                 * to the interface. The netmask is the ACK's when it carries
-                 * one, else the interface's current mask, else the one
-                 * recorded during the OFFER phase. Both are effective values
-                 * computed here, never written until the commit below. */
-                lease_ip = have_ip ? cand_ip : ee32(msg->yiaddr);
-                lease_mask = have_mask ? cand_mask
-                            : ((primary && primary->mask != 0)
-                               ? primary->mask : s->dhcp_offered_mask);
-                /* RFC 2131: the IP-address-lease-time option (51) is mandatory
-                 * in a DHCPACK. lease_s is only ever set by that option (and a
-                 * short option already returns -1 above), so lease_s != 0 means
-                 * it was present with a valid nonzero duration. Without it the
-                 * lease would be bound with no expiry/renewal timer. */
-                if (primary && saw_server_id && lease_s != 0 &&
-                    (lease_mask != 0) &&
-                    dhcp_lease_ip_sane(lease_ip, lease_mask)) {
-                    /* Commit the validated configuration atomically. */
-                    s->dhcp_server_ip = cand_server_ip;
-                    primary->ip = lease_ip;
-                    primary->mask = lease_mask;
-                    if (have_gw)
-                        primary->gw = cand_gw;
-                    if (s->dns_server == 0 && cand_dns != 0)
-                        s->dns_server = cand_dns;
-                    dhcp_cancel_timer(s);
-                    s->dhcp_ip = primary->ip;
-#ifdef ETHERNET
-                    /* RFC 4331: probe the address before using it. The
-                     * lease timers are armed now so they are in place when
-                     * the probes complete; the short DAD timer overrides
-                     * them until then. A conflicting answer is detected in
-                     * arp_recv (dhcp_dad_conflict). */
-                    s->dhcp_state = DHCP_DAD;
-                    s->dhcp_dad_probes = 0;
-                    /* Arm the lease absolutes, then swap the renew timer for
-                     * the DAD timer: handle_timers() fires every expired
-                     * entry, so leaving both in the heap would double-fire
-                     * the renew. The absolutes survive; the DAD completion
-                     * re-arms the renew timer. */
-                    dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
-                    timer_binheap_cancel(&s->timers, s->dhcp_timer);
-                    s->dhcp_timer = NO_TIMER;
-                    /* ll drivers return the frame length (>= 0) on
-                     * success, not 0; only count the probe when it
-                     * actually went out. */
-                    if (dhcp_send_dad_probe(s) >= 0)
-                        s->dhcp_dad_probes = 1;
-                    dhcp_schedule_timer_at(s,
-                            s->last_tick + DHCP_DAD_INTERVAL_MS);
-#else
-                    s->dhcp_state = DHCP_BOUND;
-                    dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
-#endif
-                    return 0;
-                }
-            }
-            break; /* the message type was seen; nothing else to scan */
+            msg_type = data[2];
         }
+        else if (code == DHCP_OPTION_SERVER_ID) {
+            uint32_t val;
+            if (len < 4)
+                return -1;
+            val = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+            /* Reject ACK from a server other than the one we committed to
+             * during the OFFER phase, wherever the option appears. */
+            if (s->dhcp_server_ip != 0 && val != s->dhcp_server_ip)
+                return -1;
+            cand_server_ip = val;
+            saw_server_id = 1;
+        }
+        else if (code == DHCP_OPTION_OFFER_IP) {
+            if (len < 4)
+                return -1;
+            cand_ip = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+            have_ip = 1;
+        }
+        else if (primary && code == DHCP_OPTION_SUBNET_MASK) {
+            if (len < 4)
+                return -1;
+            cand_mask = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+            have_mask = 1;
+        }
+        else if (primary && code == DHCP_OPTION_ROUTER) {
+            if (len < 4)
+                return -1;
+            cand_gw = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+            have_gw = 1;
+        }
+        else if ((code == DHCP_OPTION_DNS) && (s->dns_server == 0)) {
+            if (len < 4)
+                return -1;
+            if (cand_dns == 0)
+                cand_dns = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+        }
+        else if (code == DHCP_OPTION_LEASE_TIME) {
+            if (len < 4)
+                return -1;
+            lease_s = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+        }
+        else if (code == DHCP_OPTION_RENEWAL_TIME) {
+            if (len < 4)
+                return -1;
+            renew_s = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+        }
+        else if (code == DHCP_OPTION_REBIND_TIME) {
+            if (len < 4)
+                return -1;
+            rebind_s = DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+        }
+    }
+    if (!saw_end)
+        return -1;
+    if (msg_type != DHCP_ACK)
+        return -1;
+    /* The lease address is option 50 (the requested IP) when the
+     * server echoes it, otherwise the yiaddr it committed; either
+     * way it must be a usable unicast address before it is applied
+     * to the interface. The netmask is the ACK's when it carries
+     * one, else the interface's current mask, else the one
+     * recorded during the OFFER phase. Both are effective values
+     * computed here, never written until the commit below. */
+    lease_ip = have_ip ? cand_ip : ee32(msg->yiaddr);
+    lease_mask = have_mask ? cand_mask
+                : ((primary && primary->mask != 0)
+                   ? primary->mask : s->dhcp_offered_mask);
+    /* RFC 2131: the IP-address-lease-time option (51) is mandatory
+     * in a DHCPACK. lease_s is only ever set by that option (and a
+     * short option already returns -1 above), so lease_s != 0 means
+     * it was present with a valid nonzero duration. Without it the
+     * lease would be bound with no expiry/renewal timer. */
+    if (primary && saw_server_id && lease_s != 0 &&
+        (lease_mask != 0) &&
+        dhcp_lease_ip_sane(lease_ip, lease_mask)) {
+        /* Commit the validated configuration atomically. */
+        s->dhcp_server_ip = cand_server_ip;
+        primary->ip = lease_ip;
+        primary->mask = lease_mask;
+        if (have_gw)
+            primary->gw = cand_gw;
+        if (s->dns_server == 0 && cand_dns != 0)
+            s->dns_server = cand_dns;
+        dhcp_cancel_timer(s);
+        s->dhcp_ip = primary->ip;
+#ifdef ETHERNET
+        /* RFC 4331: probe the address before using it. The
+         * lease timers are armed now so they are in place when
+         * the probes complete; the short DAD timer overrides
+         * them until then. A conflicting answer is detected in
+         * arp_recv (dhcp_dad_conflict). */
+        s->dhcp_state = DHCP_DAD;
+        s->dhcp_dad_probes = 0;
+        /* Arm the lease absolutes, then swap the renew timer for
+         * the DAD timer: handle_timers() fires every expired
+         * entry, so leaving both in the heap would double-fire
+         * the renew. The absolutes survive; the DAD completion
+         * re-arms the renew timer. */
+        dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
+        timer_binheap_cancel(&s->timers, s->dhcp_timer);
+        s->dhcp_timer = NO_TIMER;
+        /* ll drivers return the frame length (>= 0) on
+         * success, not 0; only count the probe when it
+         * actually went out. */
+        if (dhcp_send_dad_probe(s) >= 0)
+            s->dhcp_dad_probes = 1;
+        dhcp_schedule_timer_at(s,
+                s->last_tick + DHCP_DAD_INTERVAL_MS);
+#else
+        s->dhcp_state = DHCP_BOUND;
+        dhcp_schedule_lease_timer(s, lease_s, renew_s, rebind_s);
+#endif
+        return 0;
     }
     return -1;
 }

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -6666,22 +6666,16 @@ int wolfIP_sock_accept(struct wolfIP *s, int sockfd, struct wolfIP_sockaddr *add
                 sin->sin_port = ee16(ts->dst_port);
                 sin->sin_addr.s_addr = ee32(ts->remote_ip);
             }
-            ts->sock.tcp.state = TCP_LISTEN;
-            tcp_ctrl_rto_stop(ts);
             /* The accepted connection owns the handshake now (its SYN-ACK
-             * lives in the clone's TX FIFO). Drop segments parked by the
-             * half-open connection: the flush refreshes a parked segment's
-             * ack from the socket's current state, so a stale SYN-ACK would
-             * be retransmitted for the listener's next connection with the
-             * new connection's ack value and a wrong destination port. */
-            fifo_init(&ts->sock.tcp.txbuf, ts->txmem, TXBUF_SIZE);
-            ts->sock.tcp.seq = wolfIP_getrandom();
-            if (ts->bound_local_ip != IPADDR_ANY) {
-                int bound_match = 0;
-                unsigned int bound_if = wolfIP_if_for_local_ip(s, ts->bound_local_ip, &bound_match);
-                ts->if_idx = bound_match ? (uint8_t)bound_if : ts->if_idx;
-                ts->local_ip = ts->bound_local_ip;
-            }
+             * lives in the clone's TX FIFO). Revert the listener to the
+             * fresh-socket baseline: the old partial reset (state, RTO,
+             * TX FIFO, seq, bound address) left the dead connection's PAWS
+             * state (last_ts/ts_enabled/ts_recent_valid), window scale,
+             * MSS and stale peer identity on the port, so the next
+             * connection inherited a stale TS.Recent and had its
+             * timestamped traffic dropped by PAWS. */
+            tcp_ctrl_rto_stop(ts);
+            tcp_listener_revert_to_listen(ts);
             if (wolfIP_filter_notify_socket_event(
                     WOLFIP_FILT_ACCEPTING, s, newts,
                     newts->local_ip, newts->src_port, newts->remote_ip, newts->dst_port) != 0) {

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8734,14 +8734,31 @@ static int dhcp_opt_stream_next(struct dhcp_opt_stream *st, uint8_t *code,
     while (1) {
         uint8_t c;
         uint8_t l;
-        if (st->ptr + 1 > st->end)
+        if (st->ptr + 1 > st->end) {
+            /* Field exhausted without an end option. */
+            if (st->strict && st->region == 0) {
+                /* RFC 2132 sec.3.2: the main options field must be
+                 * terminated by the end option; an end option found
+                 * later in an overloaded field must not satisfy the
+                 * main field's terminator. */
+                return -1;
+            }
             goto region_end;
+        }
         c = st->ptr[0];
         if (c == DHCP_OPTION_END) {
+            uint8_t *end_pos = st->ptr;
+            /* RFC 2132 sec.3.2: the end option marks the end of valid
+             * information in this field. If option 52 selected further
+             * overloaded fields, they are separate option lists
+             * (sec.9.3): skip this field's trailing pads and continue;
+             * only the final field's end option terminates the stream. */
+            st->ptr = st->end;
+            if (dhcp_opt_stream_next_region(st))
+                continue;
             *code = c;
             *len = 0;
-            *data = st->ptr;
-            st->ptr = st->end; /* stream ends here */
+            *data = end_pos;
             return 1;
         }
         if (c == 0) { /* Pad */

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -10403,6 +10403,44 @@ static inline void ip_recv(struct wolfIP *s, unsigned int if_idx,
                         broadcast);
                 return;
             }
+            /* No connected or static route to a non-local destination:
+             * discard. A router must not pass unroutable traffic on to its
+             * own protocol handlers (RFC 1122 sec.4.2.2.9). The ICMP
+             * Network Unreachable reply is a separate concern (F-1332,
+             * wont_fix) and is intentionally not sent here. */
+            return;
+            }
+            else {
+                /* l2_group (RFC 1812 sec.5.3.4): a link-layer group frame
+                 * must never be forwarded, but local delivery is legitimate
+                 * only for traffic this stack itself consumes:
+                 *  - IGMP queries/reports (router-facing, 224.0.0.x),
+                 *  - IP multicast for locally joined groups,
+                 *  - DHCP server -> client (UDP 67 -> 68): OFFER/ACK arrive
+                 *    L2-broadcast carrying an ip.dst the client does not
+                 *    own yet (RFC 2131).
+                 * Anything else is not addressed to this node: discard
+                 * instead of falling through to local dispatch. */
+                int locally_deliverable = 0;
+#ifdef IP_MULTICAST
+                if (ip->proto == WI_IPPROTO_IGMP ||
+                        wolfIP_ip_is_multicast(dest))
+                    locally_deliverable = 1;
+#endif
+                if (!locally_deliverable && ip->proto == WI_IPPROTO_UDP &&
+                        len >=
+                        (uint32_t)(ETH_HEADER_LEN + ip_hlen + UDP_HEADER_LEN)) {
+                    const uint8_t *uh =
+                        (const uint8_t *)ip + ETH_HEADER_LEN + ip_hlen;
+                    uint16_t sport, dport;
+                    memcpy(&sport, uh + 0, sizeof(sport));
+                    memcpy(&dport, uh + 2, sizeof(dport));
+                    if (ee16(sport) == DHCP_SERVER_PORT &&
+                            ee16(dport) == DHCP_CLIENT_PORT)
+                        locally_deliverable = 1;
+                }
+                if (!locally_deliverable)
+                    return;
             }
         }
     }

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -2577,6 +2577,49 @@ static int timers_binheap_insert(struct timers_binheap *heap, struct wolfIP_time
     return tmr.id;
 }
 
+/* The app tick source may be a 32-bit counter that the stack keeps
+ * zero-extended in 64-bit fields. When the source wraps (or restarts from
+ * a lower value), a plain 64-bit comparison against a pending deadline
+ * stalls until the clock lapses the old value. Compare in the source's
+ * 32-bit domain with a signed difference (RFC 1982, the same convention
+ * as the tcp_seq_* helpers): for two values within half a counter period
+ * (~24.8 days at a 1 ms tick) the sign of the modular difference is the
+ * true temporal order, which is exact for a wrapping 32-bit source and
+ * fine for any 64-bit source whose pending deadlines sit within half a
+ * 32-bit period of now. */
+static inline int tick_expired(uint64_t expires, uint64_t now)
+{
+    return (int32_t)((uint32_t)expires - (uint32_t)now) <= 0;
+}
+
+/* Move an absolute deadline from the old tick domain into the current
+ * 32-bit source domain after a rollback. A deadline already due in the
+ * new domain is clamped to fire on this poll (tick 1 when now == 0, since
+ * expires == 0 is the heap's cancelled sentinel). */
+static inline uint64_t tick_rebase(uint64_t abs, uint64_t now)
+{
+    uint32_t v = (uint32_t)abs;
+
+    if (tick_expired(v, now))
+        return (now != 0) ? now : 1;
+    return v;
+}
+
+/* Rebase the pending timer heap after a tick-source rollback (see
+ * wolfIP_poll). Every live timer expires strictly after s->last_tick, so
+ * for a realistic wrap (old tick near 2^32, new tick small) the rebased
+ * values land in [now, now + max delay] and preserve min-heap order - no
+ * re-heapify needed. */
+static void timers_heap_rebase(struct timers_binheap *heap, uint64_t now)
+{
+    uint32_t i;
+
+    for (i = 0; i < heap->size; i++) {
+        if (heap->timers[i].expires != 0)
+            heap->timers[i].expires = tick_rebase(heap->timers[i].expires, now);
+    }
+}
+
 static int is_timer_expired(struct timers_binheap *heap, uint64_t now)
 {
     while (heap->size > 0 && heap->timers[0].expires == 0) {
@@ -2585,7 +2628,7 @@ static int is_timer_expired(struct timers_binheap *heap, uint64_t now)
     if (heap->size == 0) {
         return 0;
     }
-    return (heap->timers[0].expires <= now)?1:0;
+    return tick_expired(heap->timers[0].expires, now);
 }
 
 /* Restore the min-heap property after the element at index i was replaced
@@ -11789,19 +11832,36 @@ int wolfIP_poll(struct wolfIP *s, uint64_t now)
     if (!s)
         return -WOLFIP_EINVAL;
 
-#ifdef ETHERNET
     if (now < s->last_tick) {
-        unsigned int i;
         /* The tick source restarted from a lower value (e.g. the app
-         * handed off from a bare-metal tick loop to an RTOS tick). Absolute
-         * tick values from the previous domain are no longer comparable,
-         * so reset the ARP rate limit: otherwise a stale last_arp from the
-         * old domain holds the first request in the new domain for the
-         * whole stale offset. */
-        for (i = 0; i < s->if_count; i++)
-            s->arp.last_arp[i] = 0;
-    }
+         * handed off from a bare-metal tick loop to an RTOS tick, or a
+         * 32-bit source wrapped around). Absolute tick values from the
+         * previous domain are no longer comparable, so rebase pending
+         * deadlines into the new domain: timers keep their remaining time
+         * (or fire on this poll if already due) instead of stalling until
+         * the restarted clock lapses the old absolute expiries. */
+        timers_heap_rebase(&s->timers, now);
+        if (s->dhcp_renew_at != 0)
+            s->dhcp_renew_at = tick_rebase(s->dhcp_renew_at, now);
+        if (s->dhcp_rebind_at != 0)
+            s->dhcp_rebind_at = tick_rebase(s->dhcp_rebind_at, now);
+        if (s->dhcp_lease_expires != 0)
+            s->dhcp_lease_expires = tick_rebase(s->dhcp_lease_expires, now);
+        /* The in-flight acquisition start is re-timed in the new domain
+         * so elapsed-time math never compares across domains. */
+        s->dhcp_start_tick = now;
+#ifdef ETHERNET
+        {
+            unsigned int i;
+
+            /* Also reset the ARP rate limit: otherwise a stale last_arp
+             * from the old domain holds the first request in the new
+             * domain for the whole stale offset. */
+            for (i = 0; i < s->if_count; i++)
+                s->arp.last_arp[i] = 0;
+        }
 #endif
+    }
 
     s->last_tick = now;
 

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8675,15 +8675,6 @@ struct dhcp_opt_stream {
     uint8_t region;  /* 0 options, 1 sname, 2 file */
     uint8_t overload;
     int strict;      /* -1 on malformed, or treat as end of stream */
-    /* Option in progress across a region boundary, materialized here as
-     * it is read: the sname and file fields live in separate parts of
-     * the message, so an option whose bytes span a boundary cannot be
-     * handed out as a contiguous [code, len, data...] block in place.
-     * fill is NULL when no option is in progress; the buffer holds one
-     * full option at most (1 + 1 + 255 bytes). */
-    uint8_t *fill;
-    uint8_t part_in_region0;
-    uint8_t part_buf[257];
 };
 
 static void dhcp_opt_stream_init(struct dhcp_opt_stream *st,
@@ -8702,8 +8693,6 @@ static void dhcp_opt_stream_init(struct dhcp_opt_stream *st,
     st->region = 0;
     st->overload = 0;
     st->strict = strict;
-    st->fill = NULL;
-    st->part_in_region0 = 0;
 }
 
 /* Advance the stream to the next region selected by option 52. Return 1
@@ -8745,44 +8734,6 @@ static int dhcp_opt_stream_next(struct dhcp_opt_stream *st, uint8_t *code,
     while (1) {
         uint8_t c;
         uint8_t l;
-        if (st->fill != NULL) {
-            /* Option in progress across region boundaries: pull bytes
-             * from the current region into part_buf until the option is
-             * complete. Its total size (2 + part_buf[1]) is known once
-             * the header bytes have been collected. */
-            while (st->ptr < st->end &&
-                   (st->fill < st->part_buf + 2 ||
-                    st->fill < st->part_buf + 2 + st->part_buf[1]))
-                *st->fill++ = *st->ptr++;
-            if (st->fill >= st->part_buf + 2 &&
-                st->fill >= st->part_buf + 2 + st->part_buf[1]) {
-                if (st->part_in_region0 &&
-                    st->part_buf[0] == DHCP_OPTION_OVERLOAD) {
-                    if (st->part_buf[1] != 1 || st->part_buf[2] < 1 ||
-                        st->part_buf[2] > 3) {
-                        st->fill = NULL;
-                        if (st->strict)
-                            return -1;
-                        return 0;
-                    }
-                    st->overload = st->part_buf[2];
-                }
-                *code = st->part_buf[0];
-                *len = st->part_buf[1];
-                *data = st->part_buf;
-                st->fill = NULL;
-                return 1;
-            }
-            /* Region exhausted mid-option: continue into the next
-             * overloaded region, or end the stream. */
-            if (!dhcp_opt_stream_next_region(st)) {
-                st->fill = NULL;
-                if (st->strict)
-                    return -1;
-                return 0;
-            }
-            continue;
-        }
         if (st->ptr + 1 > st->end)
             goto region_end;
         c = st->ptr[0];
@@ -8799,13 +8750,16 @@ static int dhcp_opt_stream_next(struct dhcp_opt_stream *st, uint8_t *code,
         }
         if (st->ptr + 2 > st->end ||
             st->ptr + 2 + st->ptr[1] > st->end) {
-            /* Option header or data runs past the region end. RFC 2132
-             * §9.3 makes the sname/file fields a continuation of the
-             * option stream, so materialize the option across the
-             * boundary instead of dropping it. */
-            st->fill = st->part_buf;
-            st->part_in_region0 = (st->region == 0);
-            continue;
+            /* Option header or data runs past this field's end. RFC
+             * 2132 sec.3.2: the end option marks the end of valid
+             * information in the vendor field, and sec.9.3: the
+             * overloaded fields are separate option lists interpreted
+             * after the standard option fields - an option must not
+             * span a field boundary. Strict: malformed; non-strict:
+             * end of stream, as with other truncation. */
+            if (st->strict)
+                return -1;
+            return 0;
         }
         l = st->ptr[1];
         if (st->region == 0 && c == DHCP_OPTION_OVERLOAD) {

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -8851,6 +8851,7 @@ static int dhcp_parse_offer(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg
     struct dhcp_opt_stream st;
     int saw_end = 0;
     int saw_server_id = 0;
+    int msg_type = 0;
     uint32_t ip;
     uint32_t netmask = DHCP_DEFAULT_24BIT_NETMASK;
     if (msg_len < DHCP_HEADER_LEN)
@@ -8861,6 +8862,9 @@ static int dhcp_parse_offer(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg
         return -1;
     if (ee32(msg->xid) != s->dhcp_xid)
         return -1;
+    /* RFC 2132: options are order-independent. Collect the fields in one
+     * pass regardless of order and validate the message type and the
+     * required options at the end of the stream. */
     dhcp_opt_stream_init(&st, msg, msg_len, 1);
     while (1) {
         uint8_t code;
@@ -8878,54 +8882,38 @@ static int dhcp_parse_offer(struct wolfIP *s, struct dhcp_msg *msg, uint32_t msg
         if (code == DHCP_OPTION_MSG_TYPE) {
             if (len != 1)
                 return -1;
-            if (data[2] == DHCP_OFFER) {
-                while (1) {
-                    uint8_t *idata;
-                    r = dhcp_opt_stream_next(&st, &code, &len, &idata);
-                    if (r < 0)
-                        return -1;
-                    if (r == 0)
-                        break;
-                    if (code == DHCP_OPTION_END) {
-                        saw_end = 1;
-                        break;
-                    }
-                    if (code == DHCP_OPTION_SERVER_ID) {
-                        if (len < 4)
-                            return -1;
-                        s->dhcp_server_ip =
-                            DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                        saw_server_id = 1;
-                    }
-                    if (code == DHCP_OPTION_SUBNET_MASK) {
-                        if (len < 4)
-                            return -1;
-                        netmask =
-                            DHCP_OPT_data_to_u32((struct dhcp_option *)idata);
-                    }
-                }
-                if (!saw_end || !saw_server_id)
-                    return -1;
-                ip = ee32(msg->yiaddr);
-                if (!dhcp_lease_ip_sane(ip, netmask))
-                    return -1;
-                /* Stash the offer; the interface is not reconfigured
-                 * until the server's ACK confirms the lease. */
-                s->dhcp_ip = ip;
-                s->dhcp_offered_mask = netmask;
-                dhcp_cancel_timer(s);
-                s->dhcp_state = DHCP_REQUEST_SENT;
-                return 0;
-            }
+            msg_type = data[2];
+        }
+        else if (code == DHCP_OPTION_SERVER_ID) {
+            if (len < 4)
+                return -1;
+            s->dhcp_server_ip =
+                DHCP_OPT_data_to_u32((struct dhcp_option *)data);
+            saw_server_id = 1;
+        }
+        else if (code == DHCP_OPTION_SUBNET_MASK) {
+            if (len < 4)
+                return -1;
+            netmask =
+                DHCP_OPT_data_to_u32((struct dhcp_option *)data);
         }
     }
     if (!saw_end)
         return -1;
-    if ((s->dhcp_server_ip != 0) && (s->dhcp_ip != 0)) {
-        s->dhcp_state = DHCP_REQUEST_SENT;
-        return 0;
-    }
-    return -1;
+    if (msg_type != DHCP_OFFER)
+        return -1;
+    if (!saw_server_id)
+        return -1;
+    ip = ee32(msg->yiaddr);
+    if (!dhcp_lease_ip_sane(ip, netmask))
+        return -1;
+    /* Stash the offer; the interface is not reconfigured
+     * until the server's ACK confirms the lease. */
+    s->dhcp_ip = ip;
+    s->dhcp_offered_mask = netmask;
+    dhcp_cancel_timer(s);
+    s->dhcp_state = DHCP_REQUEST_SENT;
+    return 0;
 }
 
 

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -2786,9 +2786,20 @@ static void udp_try_recv(struct wolfIP *s, unsigned int if_idx,
          * address while DHCP is running. */
         int is_dhcp = (s->dhcp_udp_sd > 0) &&
                 ((uint32_t)(MARK_UDP_SOCKET | i) == (uint32_t)s->dhcp_udp_sd);
+        /* Ingress matching uses the bound address, not the egress address
+         * selected into local_ip at bind time: a wildcard (INADDR_ANY)
+         * bind must receive datagrams addressed to any local address
+         * (POSIX), the same rule the TCP LISTEN match applies via
+         * bound_local_ip. local_ip/if_idx stay egress-only. The
+         * t->local_ip != 0 guard keeps an unbound socket (local_ip == 0)
+         * out of the match: only the DHCP relaxation above may deliver
+         * to one. */
+        int bound_match = (t->local_ip != 0) &&
+                ((t->bound_local_ip == IPADDR_ANY) ||
+                 (t->bound_local_ip == dst_ip));
         int addr_match =
                 (((t->local_ip == 0) && DHCP_IS_RUNNING(s) && is_dhcp) ||
-                 (t->local_ip == dst_ip && peer_match));
+                 (bound_match && peer_match));
 #ifdef IP_MULTICAST
         if (wolfIP_ip_is_multicast(dst_ip)) {
             addr_match = udp_socket_has_mcast(t, if_idx, dst_ip) &&

--- a/wolfesp.h
+++ b/wolfesp.h
@@ -109,15 +109,19 @@ typedef struct wolfIP_esp_sa wolfIP_esp_sa;
  * The read callback is invoked when a new SA is created, keyed by SPI.
  * It may fill the (fresh) oseq/hi_seq/bitmap values with persisted state.
  * Return 0 if state was restored, anything else to start the SA fresh.
+ *
+ * The bitmap is the full 64-bit inbound replay window
+ * (ESP_REPLAY_WIN); persisting only half of it lets a duplicate in the
+ * upper half of the window be accepted after a restore.
  * */
 typedef int (*wolfIP_esp_state_write_cb)(const uint8_t *spi,
                                          uint32_t oseq,
                                          uint32_t hi_seq,
-                                         uint32_t bitmap);
+                                         uint64_t bitmap);
 typedef int (*wolfIP_esp_state_read_cb)(const uint8_t *spi,
                                         uint32_t *oseq,
                                         uint32_t *hi_seq,
-                                        uint32_t *bitmap);
+                                        uint64_t *bitmap);
 int  wolfIP_esp_state_set_cbs(wolfIP_esp_state_write_cb write,
                               wolfIP_esp_state_read_cb read);
 


### PR DESCRIPTION
82cd690 F-11440: carry the full 64-bit ESP replay bitmap through the persistence callbacks
629451f F-11428: match wildcard UDP binds on the bound address, not the egress address
621c13c F-11427: reset full listener state on accept, not just the handshake
d648246 F-11431: rebase pending deadlines when the tick source rolls back
0ca3c58 F-11442: require the end option to terminate the main options field
c913e1b F-11441: reject DHCP options that cross a field boundary
71533c0 F-11430: parse DHCPACK options in one order-independent pass
892fd39 F-11429: parse DHCPOFFER options in one order-independent pass
ab72a3c F-11438: drop non-local datagrams that cannot be forwarded

