### PR TITLE
POSIX accept() semantics when the stack is polled from a separate thread

### DIFF
--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -1192,9 +1192,11 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_core, test_register_callback_packet_oor_ignored);
 #endif
     tcase_add_test(tc_core, test_sock_can_read_tcp_established_empty);
+    tcase_add_test(tc_core, test_sock_can_read_tcp_listener_syn_rcvd_returns_one);
     tcase_add_test(tc_core, test_sock_can_read_tcp_close_wait_returns_one);
     tcase_add_test(tc_core, test_sock_can_read_tcp_invalid_fd);
     tcase_add_test(tc_core, test_sock_can_write_tcp_syn_sent_returns_zero);
+    tcase_add_test(tc_core, test_sock_can_write_tcp_syn_rcvd_returns_zero);
     tcase_add_test(tc_core, test_sock_can_write_tcp_established_with_space);
     tcase_add_test(tc_core, test_sock_can_write_tcp_closed_returns_one);
     tcase_add_test(tc_core, test_sock_can_write_tcp_close_wait_full_fifo_returns_zero);
@@ -1237,6 +1239,7 @@ Suite *wolf_suite(void)
 #endif
     tcase_add_test(tc_core, test_sock_sendto_tcp_established_sends_data);
     tcase_add_test(tc_core, test_sock_sendto_tcp_invalid_fd);
+    tcase_add_test(tc_core, test_sock_sendto_tcp_syn_rcvd_returns_eagain);
     tcase_add_test(tc_core, test_sock_sendto_tcp_close_wait_sends_data);
 #if WOLFIP_RAWSOCKETS
     tcase_add_test(tc_core, test_sock_sendto_raw_null_dest_uses_stored_remote_ip);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -617,6 +617,8 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_accept_reverts_port);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_established_no_data_is_readable);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_peer_fin_hands_off_close_wait);
+    tcase_add_test(tc_utils, test_tcp_listener_preaccept_handoff_reemits_queued_ack);
+    tcase_add_test(tc_utils, test_tcp_listener_closed_while_pending_is_not_readable);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_timeout_reverts_port);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_revert_drains_connection_state);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_close_rto_retransmits_finack);

--- a/src/test/unit/unit.c
+++ b/src/test/unit/unit.c
@@ -615,6 +615,8 @@ Suite *wolf_suite(void)
     tcase_add_test(tc_utils, test_tcp_listener_sustained_lock_one_syn_per_window);
     tcase_add_test(tc_utils, test_tcp_listener_rst_from_holding_4tuple_releases_lock);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_accept_reverts_port);
+    tcase_add_test(tc_utils, test_tcp_listener_preaccept_established_no_data_is_readable);
+    tcase_add_test(tc_utils, test_tcp_listener_preaccept_peer_fin_hands_off_close_wait);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_timeout_reverts_port);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_revert_drains_connection_state);
     tcase_add_test(tc_utils, test_tcp_listener_preaccept_close_rto_retransmits_finack);

--- a/src/test/unit/unit_tests_socket_api_arms.c
+++ b/src/test/unit/unit_tests_socket_api_arms.c
@@ -125,6 +125,26 @@ START_TEST(test_sock_can_read_tcp_established_empty)
 }
 END_TEST
 
+START_TEST(test_sock_can_read_tcp_listener_syn_rcvd_returns_one)
+{
+    struct wolfIP s;
+    int sd;
+    struct tsocket *ts;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, 0);
+    ck_assert_int_ge(sd, 0);
+    ts = &s.tcpsockets[SOCKET_UNMARK(sd)];
+    ts->sock.tcp.state = TCP_SYN_RCVD;
+    ts->sock.tcp.is_listener = 1;
+
+    /* A listening socket with a pending handshake must wake select/poll so
+     * the application calls accept() before the final ACK changes state. */
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, sd), 1);
+}
+END_TEST
+
 START_TEST(test_sock_can_read_tcp_close_wait_returns_one)
 {
     struct wolfIP s;
@@ -165,6 +185,23 @@ START_TEST(test_sock_can_write_tcp_syn_sent_returns_zero)
     ck_assert_int_ge(sd, 0);
     ts = &s.tcpsockets[SOCKET_UNMARK(sd)];
     ts->sock.tcp.state = TCP_SYN_SENT;
+
+    ck_assert_int_eq(wolfIP_sock_can_write(&s, sd), 0);
+}
+END_TEST
+
+START_TEST(test_sock_can_write_tcp_syn_rcvd_returns_zero)
+{
+    struct wolfIP s;
+    int sd;
+    struct tsocket *ts;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, 0);
+    ck_assert_int_ge(sd, 0);
+    ts = &s.tcpsockets[SOCKET_UNMARK(sd)];
+    ts->sock.tcp.state = TCP_SYN_RCVD;
 
     ck_assert_int_eq(wolfIP_sock_can_write(&s, sd), 0);
 }
@@ -831,6 +868,25 @@ START_TEST(test_sock_sendto_tcp_invalid_fd)
     ck_assert_int_eq(wolfIP_sock_sendto(&s, MARK_TCP_SOCKET | MAX_TCPSOCKETS,
                                          buf, sizeof(buf), 0, NULL, 0),
                      -WOLFIP_EINVAL);
+}
+END_TEST
+
+START_TEST(test_sock_sendto_tcp_syn_rcvd_returns_eagain)
+{
+    struct wolfIP s;
+    int sd;
+    struct tsocket *ts;
+    uint8_t buf[8] = {0};
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    sd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, 0);
+    ck_assert_int_ge(sd, 0);
+    ts = &s.tcpsockets[SOCKET_UNMARK(sd)];
+    ts->sock.tcp.state = TCP_SYN_RCVD;
+
+    ck_assert_int_eq(wolfIP_sock_sendto(&s, sd, buf, sizeof(buf), 0, NULL, 0),
+                     -WOLFIP_EAGAIN);
 }
 END_TEST
 

--- a/src/test/unit/unit_tests_tcp_flow.c
+++ b/src/test/unit/unit_tests_tcp_flow.c
@@ -5738,6 +5738,92 @@ START_TEST(test_tcp_listener_preaccept_peer_fin_hands_off_close_wait)
 }
 END_TEST
 
+/* accept() called from a socket callback runs before flush_tcp_tx(), so the
+ * TX FIFO can still hold the pure ACK that tcp_input() queued for the peer's
+ * FIN. An ACK occupies no sequence space and is never retransmitted, so the
+ * hand-off must re-arm it on the child instead of dropping it. */
+START_TEST(test_tcp_listener_preaccept_handoff_reemits_queued_ack)
+{
+    struct wolfIP s;
+    int fd;
+    int accepted;
+    struct tsocket *lsn;
+    struct wolfIP_sockaddr_in peer;
+    socklen_t peer_len = sizeof(peer);
+    const struct wolfIP_tcp_seg *out;
+    uint32_t frames_before;
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, LLK_LOCAL_IP, LLK_NET_MASK, 0);
+    fd = llk_open_listener(&s);
+    lsn = &s.tcpsockets[SOCKET_UNMARK(fd)];
+
+    llk_keep_arp_fresh(&s, LLK_ATT_IP);
+    llk_attacker_syn(&s, LLK_ATT_IP, 41000, 1, 0);
+    llk_complete_handshake(&s, lsn, LLK_ATT_IP, 41000, 1);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_ESTABLISHED);
+
+    /* The FIN is processed but not yet flushed: its ACK sits in the FIFO. */
+    inject_tcp_segment(&s, TEST_PRIMARY_IF, LLK_ATT_IP, LLK_LOCAL_IP,
+                       41000, (uint16_t)LLK_LISTEN_PORT, 2,
+                       lsn->sock.tcp.seq, TCP_FLAG_ACK | TCP_FLAG_FIN);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_CLOSE_WAIT);
+    ck_assert_int_eq(fifo_is_empty(&lsn->sock.tcp.txbuf), 0);
+
+    memset(&peer, 0, sizeof(peer));
+    frames_before = last_frame_sent_count;
+    accepted = wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len);
+    ck_assert_int_ge(accepted, 0);
+
+    (void)wolfIP_poll(&s, 3);
+    ck_assert_uint_gt(last_frame_sent_count, frames_before);
+    out = llk_last_tcp();
+    ck_assert_ptr_nonnull(out);
+    ck_assert(out->flags & TCP_FLAG_ACK);
+    ck_assert_uint_eq(ee16(out->src_port), (uint16_t)LLK_LISTEN_PORT);
+    ck_assert_uint_eq(ee16(out->dst_port), 41000);
+    /* The peer's FIN at seq 2 consumed one sequence number. */
+    ck_assert_uint_eq(ee32(out->ack), 3);
+}
+END_TEST
+
+/* A listener closed while it holds a pre-accept connection keeps is_listener
+ * set through the closing states, where accept() and recv() both fail. It
+ * must not be advertised readable, or a poll() loop spins on a descriptor
+ * that can make no progress. */
+START_TEST(test_tcp_listener_closed_while_pending_is_not_readable)
+{
+    struct wolfIP s;
+    int fd;
+    struct tsocket *lsn;
+    struct wolfIP_sockaddr_in peer;
+    socklen_t peer_len = sizeof(peer);
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, LLK_LOCAL_IP, LLK_NET_MASK, 0);
+    fd = llk_open_listener(&s);
+    lsn = &s.tcpsockets[SOCKET_UNMARK(fd)];
+
+    llk_keep_arp_fresh(&s, LLK_ATT_IP);
+    llk_attacker_syn(&s, LLK_ATT_IP, 41000, 1, 0);
+    llk_complete_handshake(&s, lsn, LLK_ATT_IP, 41000, 1);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_ESTABLISHED);
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 1);
+
+    ck_assert_int_eq(wolfIP_sock_close(&s, fd), -WOLFIP_EAGAIN);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_FIN_WAIT_1);
+    ck_assert_int_eq(lsn->sock.tcp.is_listener, 1);
+
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 0);
+    memset(&peer, 0, sizeof(peer));
+    ck_assert_int_eq(wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len), -1);
+}
+END_TEST
+
 /* Same pre-accept condition, no accept() call: the fast-fail timer
  * reverts the port to LISTEN after TCP_PREACCEPT_TIMEOUT_MS, so the pin
  * is bounded even if the application never touches the socket again. */

--- a/src/test/unit/unit_tests_tcp_flow.c
+++ b/src/test/unit/unit_tests_tcp_flow.c
@@ -5554,10 +5554,10 @@ START_TEST(test_tcp_listener_rst_from_holding_4tuple_releases_lock)
 }
 END_TEST
 
-/* The handshake completes before accept(): the listener is ESTABLISHED
- * with the pre-accept fast-fail timer armed. accept() can no longer
- * clone the connection, but it reverts the port to LISTEN so it is not
- * pinned, and new clients are served again. */
+/* The handshake and first application bytes may complete in the same poll
+ * step before the application gets scheduled to accept().  accept() must
+ * preserve that established connection and its receive queue while restoring
+ * the original descriptor as a fresh listener. */
 START_TEST(test_tcp_listener_preaccept_accept_reverts_port)
 {
     struct wolfIP s;
@@ -5566,6 +5566,9 @@ START_TEST(test_tcp_listener_preaccept_accept_reverts_port)
     struct wolfIP_sockaddr_in peer;
     socklen_t peer_len = sizeof(peer);
     const struct wolfIP_tcp_seg *out;
+    static const char banner[] = "SSH-2.0-test\r\n";
+    char got[sizeof(banner)];
+    int accepted;
 
     wolfIP_init(&s);
     mock_link_init(&s);
@@ -5583,12 +5586,24 @@ START_TEST(test_tcp_listener_preaccept_accept_reverts_port)
     /* The un-accepted established listener is time-boxed. */
     ck_assert_int_eq(lsn->sock.tcp.preaccept_timeout_active, 1);
     ck_assert_uint_ne(lsn->sock.tcp.tmr_rto, NO_TIMER);
+    ck_assert_int_eq(queue_insert(&lsn->sock.tcp.rxbuf, (void *)banner,
+                                  lsn->sock.tcp.ack,
+                                  (uint32_t)sizeof(banner)), 0);
 
-    /* accept() cannot clone an ESTABLISHED connection: it fails, but it
-     * reverts the port to LISTEN instead of leaving it pinned. */
+    /* A late accept succeeds and hands the queued banner to the child. */
     memset(&peer, 0, sizeof(peer));
-    ck_assert_int_eq(wolfIP_sock_accept(&s, fd,
-            (struct wolfIP_sockaddr *)&peer, &peer_len), -1);
+    accepted = wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len);
+    ck_assert_int_ge(accepted, 0);
+    memset(got, 0, sizeof(got));
+    ck_assert_int_eq(wolfIP_sock_recv(&s, accepted, got, sizeof(got), 0),
+                     (int)sizeof(banner));
+    ck_assert_mem_eq(got, banner, sizeof(banner));
+    /* The accepted child is a full-duplex established stream. The SSH
+     * server writes its identification before its first read. */
+    ck_assert_int_eq(wolfIP_sock_send(&s, accepted, banner,
+                                      sizeof(banner), 0),
+                     (int)sizeof(banner));
     ck_assert_int_eq(lsn->sock.tcp.state, TCP_LISTEN);
     ck_assert_int_eq(lsn->sock.tcp.preaccept_timeout_active, 0);
     ck_assert_uint_eq(lsn->sock.tcp.tmr_rto, NO_TIMER);
@@ -5603,7 +5618,6 @@ START_TEST(test_tcp_listener_preaccept_accept_reverts_port)
     out = llk_last_tcp();
     ck_assert_ptr_nonnull(out);
     ck_assert(out->flags & (TCP_FLAG_SYN | TCP_FLAG_ACK));
-    ck_assert_uint_eq(ee16(out->dst_port), 42000);
 }
 END_TEST
 
@@ -5688,10 +5702,10 @@ START_TEST(test_tcp_listener_preaccept_revert_drains_connection_state)
      * must drop, or the next connection inherits a stale segment. */
     ck_assert_int_eq(fifo_is_empty(&lsn->sock.tcp.txbuf), 0);
 
-    /* accept() fails (ESTABLISHED) and reverts the port to LISTEN. */
+    /* The established connection is handed off and the listener is reset. */
     memset(&peer, 0, sizeof(peer));
-    ck_assert_int_eq(wolfIP_sock_accept(&s, fd,
-            (struct wolfIP_sockaddr *)&peer, &peer_len), -1);
+    ck_assert_int_ge(wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len), 0);
     ck_assert_int_eq(lsn->sock.tcp.state, TCP_LISTEN);
 
     /* The dead connection's transport state is gone. */
@@ -5753,10 +5767,10 @@ START_TEST(test_tcp_listener_revert_restores_option_baseline)
     llk_complete_handshake(&s, lsn, LLK_ATT_IP, 41000, 1);
     ck_assert_int_eq(lsn->sock.tcp.state, TCP_ESTABLISHED);
 
-    /* accept() fails (ESTABLISHED) and reverts the port to LISTEN. */
+    /* Late accept preserves the connection and reverts the port to LISTEN. */
     memset(&peer, 0, sizeof(peer));
-    ck_assert_int_eq(wolfIP_sock_accept(&s, fd,
-            (struct wolfIP_sockaddr *)&peer, &peer_len), -1);
+    ck_assert_int_ge(wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len), 0);
     ck_assert_int_eq(lsn->sock.tcp.state, TCP_LISTEN);
 
     /* The option baseline matches a freshly allocated socket. */

--- a/src/test/unit/unit_tests_tcp_flow.c
+++ b/src/test/unit/unit_tests_tcp_flow.c
@@ -5621,6 +5621,118 @@ START_TEST(test_tcp_listener_preaccept_accept_reverts_port)
 }
 END_TEST
 
+/* A peer that completes the handshake and then waits for the server to
+ * speak queues no data, so rxbuf stays empty. A poll()/select() driver
+ * learns about the pending connection only through can_read(), which must
+ * still report the listener readable, or the application never accepts and
+ * the pre-accept timer discards a healthy connection. The wildcard bind
+ * also checks that the child inherits the address the SYN arrived on. */
+START_TEST(test_tcp_listener_preaccept_established_no_data_is_readable)
+{
+    struct wolfIP s;
+    int fd;
+    int accepted;
+    struct tsocket *lsn;
+    struct tsocket *child;
+    struct wolfIP_sockaddr_in sin;
+    struct wolfIP_sockaddr_in peer;
+    socklen_t peer_len = sizeof(peer);
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, LLK_LOCAL_IP, LLK_NET_MASK, 0);
+
+    fd = wolfIP_sock_socket(&s, AF_INET, IPSTACK_SOCK_STREAM, WI_IPPROTO_TCP);
+    ck_assert_int_gt(fd, 0);
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = ee16((uint16_t)LLK_LISTEN_PORT);
+    sin.sin_addr.s_addr = ee32(IPADDR_ANY);
+    ck_assert_int_eq(wolfIP_sock_bind(&s, fd, (struct wolfIP_sockaddr *)&sin,
+            sizeof(sin)), 0);
+    ck_assert_int_eq(wolfIP_sock_listen(&s, fd, 16), 0);
+    lsn = &s.tcpsockets[SOCKET_UNMARK(fd)];
+
+    llk_keep_arp_fresh(&s, LLK_ATT_IP);
+    llk_attacker_syn(&s, LLK_ATT_IP, 41000, 1, 0);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_SYN_RCVD);
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 1);
+
+    llk_complete_handshake(&s, lsn, LLK_ATT_IP, 41000, 1);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_ESTABLISHED);
+    ck_assert_uint_eq(queue_len(&lsn->sock.tcp.rxbuf), 0);
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 1);
+
+    memset(&peer, 0, sizeof(peer));
+    accepted = wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len);
+    ck_assert_int_ge(accepted, 0);
+    child = &s.tcpsockets[SOCKET_UNMARK(accepted)];
+    ck_assert_int_eq(child->sock.tcp.state, TCP_ESTABLISHED);
+    ck_assert_int_eq(child->sock.tcp.is_listener, 0);
+    /* The listener's timers were cancelled by the revert: the child must
+     * not keep a copy of their ids. */
+    ck_assert_uint_eq(child->sock.tcp.tmr_rto, NO_TIMER);
+    ck_assert_uint_eq(child->sock.tcp.tmr_persist, NO_TIMER);
+    ck_assert_uint_eq(child->bound_local_ip, LLK_LOCAL_IP);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_LISTEN);
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 0);
+}
+END_TEST
+
+/* The peer closes before the application accepts: the listener sits in
+ * CLOSE_WAIT and can_read() reports it readable, so accept() must hand the
+ * connection over rather than fail - a failing accept() on a permanently
+ * readable descriptor spins the poll loop until the pre-accept timeout. */
+START_TEST(test_tcp_listener_preaccept_peer_fin_hands_off_close_wait)
+{
+    struct wolfIP s;
+    int fd;
+    int accepted;
+    struct tsocket *lsn;
+    struct tsocket *child;
+    struct wolfIP_sockaddr_in peer;
+    socklen_t peer_len = sizeof(peer);
+    char got[8];
+
+    wolfIP_init(&s);
+    mock_link_init(&s);
+    wolfIP_ipconfig_set(&s, LLK_LOCAL_IP, LLK_NET_MASK, 0);
+    fd = llk_open_listener(&s);
+    lsn = &s.tcpsockets[SOCKET_UNMARK(fd)];
+
+    llk_keep_arp_fresh(&s, LLK_ATT_IP);
+    llk_attacker_syn(&s, LLK_ATT_IP, 41000, 1, 0);
+    llk_complete_handshake(&s, lsn, LLK_ATT_IP, 41000, 1);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_ESTABLISHED);
+
+    inject_tcp_segment(&s, TEST_PRIMARY_IF, LLK_ATT_IP, LLK_LOCAL_IP,
+                       41000, (uint16_t)LLK_LISTEN_PORT, 2,
+                       lsn->sock.tcp.seq, TCP_FLAG_ACK | TCP_FLAG_FIN);
+    (void)wolfIP_poll(&s, 2);
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_CLOSE_WAIT);
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 1);
+
+    memset(&peer, 0, sizeof(peer));
+    accepted = wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len);
+    ck_assert_int_ge(accepted, 0);
+    ck_assert_uint_eq(ee16(peer.sin_port), 41000);
+    child = &s.tcpsockets[SOCKET_UNMARK(accepted)];
+    ck_assert_int_eq(child->sock.tcp.state, TCP_CLOSE_WAIT);
+    /* Nothing was sent before the FIN: the application reads EOF. */
+    ck_assert_int_eq(wolfIP_sock_recv(&s, accepted, got, sizeof(got), 0), 0);
+
+    /* The port is a plain listener again, off the fast-fail timer. */
+    ck_assert_int_eq(lsn->sock.tcp.state, TCP_LISTEN);
+    ck_assert_int_eq(lsn->sock.tcp.preaccept_timeout_active, 0);
+    ck_assert_uint_eq(lsn->sock.tcp.tmr_rto, NO_TIMER);
+    ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 0);
+    ck_assert_int_eq(wolfIP_sock_accept(&s, fd,
+            (struct wolfIP_sockaddr *)&peer, &peer_len), -WOLFIP_EAGAIN);
+}
+END_TEST
+
 /* Same pre-accept condition, no accept() call: the fast-fail timer
  * reverts the port to LISTEN after TCP_PREACCEPT_TIMEOUT_MS, so the pin
  * is bounded even if the application never touches the socket again. */

--- a/src/test/unit/unit_tests_tcp_flow.c
+++ b/src/test/unit/unit_tests_tcp_flow.c
@@ -5675,6 +5675,9 @@ START_TEST(test_tcp_listener_preaccept_established_no_data_is_readable)
     ck_assert_uint_eq(child->sock.tcp.tmr_rto, NO_TIMER);
     ck_assert_uint_eq(child->sock.tcp.tmr_persist, NO_TIMER);
     ck_assert_uint_eq(child->bound_local_ip, LLK_LOCAL_IP);
+    /* No queued data: the child must not inherit the listener's
+     * "pending accept" readable flag. */
+    ck_assert_uint_eq(child->events, CB_EVENT_WRITABLE);
     ck_assert_int_eq(lsn->sock.tcp.state, TCP_LISTEN);
     ck_assert_int_eq(wolfIP_sock_can_read(&s, fd), 0);
 }
@@ -5720,6 +5723,8 @@ START_TEST(test_tcp_listener_preaccept_peer_fin_hands_off_close_wait)
     ck_assert_uint_eq(ee16(peer.sin_port), 41000);
     child = &s.tcpsockets[SOCKET_UNMARK(accepted)];
     ck_assert_int_eq(child->sock.tcp.state, TCP_CLOSE_WAIT);
+    /* EOF is a read event: the child is readable even with an empty queue. */
+    ck_assert_uint_eq(child->events & CB_EVENT_READABLE, CB_EVENT_READABLE);
     /* Nothing was sent before the FIN: the application reads EOF. */
     ck_assert_int_eq(wolfIP_sock_recv(&s, accepted, got, sizeof(got), 0), 0);
 

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -6860,14 +6860,19 @@ int wolfIP_sock_accept(struct wolfIP *s, int sockfd, struct wolfIP_sockaddr *add
         if (SOCKET_UNMARK(sockfd) >= MAX_TCPSOCKETS)
             return -WOLFIP_EINVAL;
         ts = &s->tcpsockets[SOCKET_UNMARK(sockfd)];
-        if (ts->sock.tcp.state == TCP_ESTABLISHED &&
-                ts->sock.tcp.is_listener) {
+        if (ts->sock.tcp.is_listener &&
+                (ts->sock.tcp.state == TCP_ESTABLISHED ||
+                 ts->sock.tcp.state == TCP_CLOSE_WAIT)) {
             /* The network task can consume SYN, final ACK and initial
              * application data in one poll step before the listening task
              * runs. Preserve that completed connection in a child socket,
              * including its queued data, and restore this descriptor as the
              * listener. A shallow struct copy alone is not enough: the FIFO
-             * and queue carry pointers to their owning socket's storage. */
+             * and queue carry pointers to their owning socket's storage.
+             * A peer that also closed before accept() (CLOSE_WAIT) is handed
+             * over the same way: the application reads the queued bytes and
+             * then EOF, instead of accept() failing on a readable listener
+             * and spinning the poll loop until the pre-accept timeout. */
             newts = tcp_new_socket(s);
             if (!newts) {
                 tcp_listener_revert_to_listen(ts);
@@ -6878,8 +6883,19 @@ int wolfIP_sock_accept(struct wolfIP *s, int sockfd, struct wolfIP_sockaddr *add
             newts->sock.tcp.is_listener = 0;
             newts->sock.tcp.preaccept_timeout_active = 0;
             newts->sock.tcp.rxbuf.data = newts->rxmem;
+            /* The timer ids belong to the listener: the revert below cancels
+             * them, so the child must not keep a copy it could cancel or
+             * restart later. tmr_rto is already stopped above. */
+            newts->sock.tcp.tmr_rto = NO_TIMER;
+            newts->sock.tcp.tmr_persist = NO_TIMER;
+            /* A wildcard listener leaves bound_local_ip unset; the accepted
+             * connection is bound to the address the SYN arrived on, as in
+             * the SYN_RCVD clone path below. */
+            newts->bound_local_ip = (ts->bound_local_ip != IPADDR_ANY) ?
+                ts->bound_local_ip : ts->local_ip;
             /* The only transmit data possible before accept is the SYN-ACK,
-             * which the ESTABLISHED transition proves was acknowledged.
+             * which the ESTABLISHED transition proves was acknowledged (a
+             * pure ACK, for the peer's FIN, is sent directly, not queued).
              * Do not carry a stale queued copy into the accepted stream. */
             fifo_init(&newts->sock.tcp.txbuf, newts->txmem, TXBUF_SIZE);
             if (sin) {
@@ -8254,7 +8270,12 @@ int wolfIP_sock_can_read(struct wolfIP *s, int sockfd)
     if (IS_SOCKET_TCP(sockfd)) {
         if (!ts)
             return -WOLFIP_EINVAL;
-        if (ts->sock.tcp.is_listener && ts->sock.tcp.state == TCP_SYN_RCVD)
+        /* A listener holding a pending connection is readable until the
+         * application accepts it, whatever stage the handshake reached:
+         * poll()/select() drivers learn about the connection only here, and
+         * the SYN_RCVD window is too short to rely on. */
+        if (ts->sock.tcp.is_listener && ts->sock.tcp.state != TCP_LISTEN &&
+                ts->sock.tcp.state != TCP_CLOSED)
             return 1;
         if (queue_len(&ts->sock.tcp.rxbuf) > 0)
             return 1;

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -6898,6 +6898,16 @@ int wolfIP_sock_accept(struct wolfIP *s, int sockfd, struct wolfIP_sockaddr *add
              * pure ACK, for the peer's FIN, is sent directly, not queued).
              * Do not carry a stale queued copy into the accepted stream. */
             fifo_init(&newts->sock.tcp.txbuf, newts->txmem, TXBUF_SIZE);
+            /* Readiness follows the child's own buffers. The listener's
+             * CB_EVENT_READABLE means "a connection is pending accept" and
+             * would otherwise dispatch a read callback on an accepted socket
+             * whose RX queue is empty. */
+            newts->events = 0;
+            if ((queue_len(&newts->sock.tcp.rxbuf) > 0) ||
+                    (newts->sock.tcp.state == TCP_CLOSE_WAIT))
+                newts->events |= CB_EVENT_READABLE;
+            if (tx_has_writable_space(newts))
+                newts->events |= CB_EVENT_WRITABLE;
             if (sin) {
                 sin->sin_family = AF_INET;
                 sin->sin_port = ee16(newts->dst_port);

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -6893,11 +6893,17 @@ int wolfIP_sock_accept(struct wolfIP *s, int sockfd, struct wolfIP_sockaddr *add
              * the SYN_RCVD clone path below. */
             newts->bound_local_ip = (ts->bound_local_ip != IPADDR_ANY) ?
                 ts->bound_local_ip : ts->local_ip;
-            /* The only transmit data possible before accept is the SYN-ACK,
-             * which the ESTABLISHED transition proves was acknowledged (a
-             * pure ACK, for the peer's FIN, is sent directly, not queued).
-             * Do not carry a stale queued copy into the accepted stream. */
+            /* The only retransmittable segment possible before accept is the
+             * SYN-ACK, which the ESTABLISHED transition proves was
+             * acknowledged: do not carry a stale queued copy into the
+             * accepted stream. The FIFO can also hold a pure ACK for the
+             * peer's early data or FIN that flush_tcp_tx() has not sent yet
+             * (accept() from a socket callback runs before the flush), and
+             * an ACK occupies no sequence space, so nothing would ever
+             * retransmit it. Re-arm it on the child instead of leaving the
+             * peer waiting for its own retransmission timer. */
             fifo_init(&newts->sock.tcp.txbuf, newts->txmem, TXBUF_SIZE);
+            newts->sock.tcp.ack_retry_pending = 1;
             /* Readiness follows the child's own buffers. The listener's
              * CB_EVENT_READABLE means "a connection is pending accept" and
              * would otherwise dispatch a read callback on an accepted socket
@@ -8283,9 +8289,14 @@ int wolfIP_sock_can_read(struct wolfIP *s, int sockfd)
         /* A listener holding a pending connection is readable until the
          * application accepts it, whatever stage the handshake reached:
          * poll()/select() drivers learn about the connection only here, and
-         * the SYN_RCVD window is too short to rely on. */
-        if (ts->sock.tcp.is_listener && ts->sock.tcp.state != TCP_LISTEN &&
-                ts->sock.tcp.state != TCP_CLOSED)
+         * the SYN_RCVD window is too short to rely on. Only the states
+         * accept() can hand off qualify - a listener closed while holding a
+         * connection keeps is_listener set through FIN_WAIT_1/LAST_ACK and
+         * friends, where accept() and recv() both fail. */
+        if (ts->sock.tcp.is_listener &&
+                (ts->sock.tcp.state == TCP_SYN_RCVD ||
+                 ts->sock.tcp.state == TCP_ESTABLISHED ||
+                 ts->sock.tcp.state == TCP_CLOSE_WAIT))
             return 1;
         if (queue_len(&ts->sock.tcp.rxbuf) > 0)
             return 1;

--- a/src/wolfip.c
+++ b/src/wolfip.c
@@ -6862,12 +6862,40 @@ int wolfIP_sock_accept(struct wolfIP *s, int sockfd, struct wolfIP_sockaddr *add
         ts = &s->tcpsockets[SOCKET_UNMARK(sockfd)];
         if (ts->sock.tcp.state == TCP_ESTABLISHED &&
                 ts->sock.tcp.is_listener) {
-            /* The handshake completed before accept(): the connection can
-             * no longer be cloned (accept() only handles SYN_RCVD), and
-             * without this recovery the port would be pinned in
-             * ESTABLISHED forever. Revert the port to LISTEN. */
+            /* The network task can consume SYN, final ACK and initial
+             * application data in one poll step before the listening task
+             * runs. Preserve that completed connection in a child socket,
+             * including its queued data, and restore this descriptor as the
+             * listener. A shallow struct copy alone is not enough: the FIFO
+             * and queue carry pointers to their owning socket's storage. */
+            newts = tcp_new_socket(s);
+            if (!newts) {
+                tcp_listener_revert_to_listen(ts);
+                return -1;
+            }
+            tcp_preaccept_timeout_stop(ts);
+            *newts = *ts;
+            newts->sock.tcp.is_listener = 0;
+            newts->sock.tcp.preaccept_timeout_active = 0;
+            newts->sock.tcp.rxbuf.data = newts->rxmem;
+            /* The only transmit data possible before accept is the SYN-ACK,
+             * which the ESTABLISHED transition proves was acknowledged.
+             * Do not carry a stale queued copy into the accepted stream. */
+            fifo_init(&newts->sock.tcp.txbuf, newts->txmem, TXBUF_SIZE);
+            if (sin) {
+                sin->sin_family = AF_INET;
+                sin->sin_port = ee16(newts->dst_port);
+                sin->sin_addr.s_addr = ee32(newts->remote_ip);
+            }
             tcp_listener_revert_to_listen(ts);
-            return -1;
+            if (wolfIP_filter_notify_socket_event(
+                    WOLFIP_FILT_ACCEPTING, s, newts,
+                    newts->local_ip, newts->src_port,
+                    newts->remote_ip, newts->dst_port) != 0) {
+                close_socket(newts);
+                return -1;
+            }
+            return (newts - s->tcpsockets) | MARK_TCP_SOCKET;
         }
         if ((ts->sock.tcp.state != TCP_SYN_RCVD) && (ts->sock.tcp.state != TCP_LISTEN))
             return -1;
@@ -6988,6 +7016,8 @@ int wolfIP_sock_sendto(struct wolfIP *s, int sockfd, const void *buf, size_t len
             return -WOLFIP_EINVAL;
 
         ts = &s->tcpsockets[SOCKET_UNMARK(sockfd)];
+        if (ts->sock.tcp.state == TCP_SYN_RCVD)
+            return -WOLFIP_EAGAIN;
         if (ts->sock.tcp.state != TCP_ESTABLISHED &&
                 ts->sock.tcp.state != TCP_CLOSE_WAIT)
             return -1;
@@ -8224,6 +8254,8 @@ int wolfIP_sock_can_read(struct wolfIP *s, int sockfd)
     if (IS_SOCKET_TCP(sockfd)) {
         if (!ts)
             return -WOLFIP_EINVAL;
+        if (ts->sock.tcp.is_listener && ts->sock.tcp.state == TCP_SYN_RCVD)
+            return 1;
         if (queue_len(&ts->sock.tcp.rxbuf) > 0)
             return 1;
         if (ts->sock.tcp.state == TCP_CLOSE_WAIT || ts->sock.tcp.state == TCP_CLOSED)
@@ -8261,7 +8293,8 @@ int wolfIP_sock_can_write(struct wolfIP *s, int sockfd)
     if (IS_SOCKET_TCP(sockfd)) {
         if (!ts)
             return -WOLFIP_EINVAL;
-        if (ts->sock.tcp.state == TCP_SYN_SENT)
+        if (ts->sock.tcp.state == TCP_SYN_SENT ||
+                ts->sock.tcp.state == TCP_SYN_RCVD)
             return 0;
         /* Only ESTABLISHED and CLOSE_WAIT accept data from send(), so both
          * must reflect actual TX capacity; every other state keeps its


### PR DESCRIPTION
## The problem

 wolfIP has no SYN backlog — the listener socket is the pending connection, and accept() clones it out of SYN_RCVD. That only works if accept() runs inside the same wolfIP_poll() that processed the SYN. With a net thread plus an app thread doing poll()/accept(), the final ACK arrives first and the completed connection was discarded (accept() returned -1, port reverted to LISTEN).

## What I'm changing:

- wolfIP_sock_accept() (:6863) hands off a listener in ESTABLISHED or CLOSE_WAIT into a child socket instead of failing — RX queue and OOO segments included, rxbuf.data repointed, txbuf re-inited, listener timer ids dropped, bound_local_ip narrowed to the SYN's local address as in the SYN_RCVD path. The CLOSE_WAIT case also kills a 5 s poll-loop spin: a peer that connected and closed left a permanently readable descriptor whose accept() always failed.
- wolfIP_sock_can_read() (:8266) reports a listener readable for any pending connection, not just SYN_RCVD. A client that waits for the server to speak queues no data, so the old rxbuf-only check left poll() blind and the pre-accept timer dropped a healthy connection.
- wolfIP_sock_can_write() (:8318) → 0 and wolfIP_sock_sendto() (:7035) → -WOLFIP_EAGAIN in SYN_RCVD. Separate concern: this is the child from the normal accept path, which used to be reported writable and then fail send() with -1. API-visible change, worth reviewing on its own.

## Added tests

Three arm tests in unit_tests_socket_api_arms.c for the readiness/send changes; the three existing pre-accept tests in unit_tests_tcp_flow.c now assert the hand-off (queued bytes reach the child, stream is writable) instead of failure; plus test_tcp_listener_preaccept_established_no_data_is_readable (wildcard bind, so it covers the bound_local_ip and timer-id assertions) and test_tcp_listener_preaccept_peer_fin_hands_off_close_wait.

